### PR TITLE
Fixed a bug where the timeout defaulted to 5ms instead of 5s

### DIFF
--- a/Java/me/dilley/MineStat.java
+++ b/Java/me/dilley/MineStat.java
@@ -161,12 +161,12 @@ public class MineStat
 
   public int getTimeout()
   {
-    return timeout * 1000;         // milliseconds
+    return timeout;         // milliseconds
   }
 
   public void setTimeout(int timeout)
   {
-    this.timeout = timeout * 1000; // milliseconds
+    this.timeout = timeout; // milliseconds
   }
 
   public String getMotd()

--- a/Java/me/dilley/MineStat.java
+++ b/Java/me/dilley/MineStat.java
@@ -19,7 +19,7 @@
  */
 
 /**
- * @author Lloyd Dilley, Arne Sacnussem
+ * @author Lloyd Dilley, Arne Sacnussem, grimsi
  */
 
 package me.dilley;
@@ -79,7 +79,7 @@ public class MineStat
 
   public MineStat(String address, int port)
   {
-    this(address, port, DEFAULT_TIMEOUT);
+    this(address, port, DEFAULT_TIMEOUT * 1000);
   }
 
   public MineStat(String address, int port, int timeout)
@@ -125,7 +125,7 @@ public class MineStat
     else
     {
       serverData = rawServerData.split("\u0000\u0000\u0000");
-      if(serverData != null && serverData.length >= NUM_FIELDS)
+      if(serverData.length >= NUM_FIELDS)
       {
         serverUp = true;
         setVersion(serverData[2].replace("\u0000", ""));


### PR DESCRIPTION
Closes #35 

Additions/modifications proposed in this pull request:
- Moved logic from getters and setters to constructor
- Removed unnecessary null-check in MineStat.java:128 (serverData is always non-null)
