### PR TITLE
New Python module, supporting all ping types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@ MYMETA.yml
 obj/
 pm_to_blib
 tests/
+
+# Ignore Python virtual environments
+venv/

--- a/Python/example.py
+++ b/Python/example.py
@@ -8,5 +8,6 @@ if ms.online:
   print('Server is online running version %s with %s out of %s players.' % (ms.version, ms.current_players, ms.max_players))
   print('Message of the day: %s' % ms.motd)
   print('Latency: %sms' % ms.latency)
+  print('Connected using protocol: %s' % ms.slp_protocol)
 else:
   print('Server is offline!')

--- a/Python/minestat/__init__.py
+++ b/Python/minestat/__init__.py
@@ -18,8 +18,7 @@
 
 import socket
 import struct
-from datetime import datetime
-from time import perf_counter, perf_counter_ns
+from time import perf_counter
 from enum import Enum
 from typing import Union
 

--- a/Python/minestat/__init__.py
+++ b/Python/minestat/__init__.py
@@ -105,7 +105,7 @@ class MineStat:
       self.latency = round((perf_counter() - start_time) * 1000)
     except socket.timeout:
       return ConnStatus.TIMEOUT
-    except:
+    except OSError:
       return ConnStatus.CONNFAIL
 
     # Construct Handshake packet
@@ -136,7 +136,7 @@ class MineStat:
       packet_len = self._unpack_varint(sock)
     except socket.timeout:
       return ConnStatus.TIMEOUT
-    except:
+    except OSError:
       return ConnStatus.CONNFAIL
 
     # Receive actual packet id
@@ -234,7 +234,7 @@ class MineStat:
       self.latency = round((perf_counter() - start_time) * 1000)
     except socket.timeout:
       return ConnStatus.TIMEOUT
-    except:
+    except OSError:
       return ConnStatus.CONNFAIL
 
     # Send 0xFE as packet identifier,
@@ -268,7 +268,7 @@ class MineStat:
       raw_header = sock.recv(3)
     except socket.timeout:
       return ConnStatus.TIMEOUT
-    except:
+    except OSError:
       return ConnStatus.CONNFAIL
 
     # Extract payload length
@@ -301,7 +301,7 @@ class MineStat:
       self.latency = round((perf_counter() - start_time) * 1000)
     except socket.timeout:
       return ConnStatus.TIMEOUT
-    except:
+    except OSError:
       return ConnStatus.CONNFAIL
 
     # Send 0xFE 0x01 as packet id
@@ -312,7 +312,7 @@ class MineStat:
       raw_header = sock.recv(3)
     except socket.timeout:
       return ConnStatus.TIMEOUT
-    except:
+    except OSError:
       return ConnStatus.CONNFAIL
 
     # Extract payload length
@@ -382,7 +382,7 @@ class MineStat:
       self.latency = round((perf_counter() - start_time) * 1000)
     except socket.timeout:
       return ConnStatus.TIMEOUT
-    except:
+    except OSError:
       return ConnStatus.CONNFAIL
 
     # Send 0xFE as packet id
@@ -393,7 +393,7 @@ class MineStat:
       raw_header = sock.recv(3)
     except socket.timeout:
       return ConnStatus.TIMEOUT
-    except:
+    except OSError:
       return ConnStatus.CONNFAIL
 
     # Extract payload length

--- a/Python/minestat/__init__.py
+++ b/Python/minestat/__init__.py
@@ -29,13 +29,21 @@ Contains possible connection states.
 
 - `SUCCESS`: The specified SLP connection succeeded (Request & response parsing OK)
 - `CONNFAIL`: The socket to the server could not be established. Server offline, wrong hostname or port?
-- `TIMEOUT`:
+- `TIMEOUT`: The connection timed out. (Server under too much load? Firewall rules OK?)
+- `UNKNOWN`: The connection was established, but the server spoke an unknown/unsupported SLP protocol.
   """
 
   SUCCESS = 0
+  """The specified SLP connection succeeded (Request & response parsing OK)"""
+
   CONNFAIL = -1
+  """The socket to the server could not be established. (Server offline, wrong hostname or port?)"""
+
   TIMEOUT = -2
+  """The connection timed out. (Server under too much load? Firewall rules OK?)"""
+
   UNKNOWN = -3
+  """The connection was established, but the server spoke an unknown/unsupported SLP protocol."""
 
 
 class MineStat:

--- a/Python/minestat/__init__.py
+++ b/Python/minestat/__init__.py
@@ -17,18 +17,27 @@
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 import socket
+import struct
 from datetime import datetime
+from enum import Enum
+
+
+class ConnectionStatus(Enum):
+  """
+  TODO: Document
+  """
+
+  SUCCESS = 0
+  CONNFAIL = -1
+  TIMEOUT = -2
+  UNKNOWN = -3
+
 
 class MineStat:
-  VERSION = "1.0.1"             # MineStat version
+  VERSION = "2.0.0"             # MineStat version
   NUM_FIELDS = 6                # number of values expected from server
   NUM_FIELDS_BETA = 3           # number of values expected from a 1.8b/1.3 server
   DEFAULT_TIMEOUT = 5           # default TCP timeout in seconds
-
-  def enum(**enums):
-    return type('Enum', (), enums)
-
-  Retval = enum(SUCCESS = 0, CONNFAIL = -1, TIMEOUT = -2, UNKNOWN = -3)
 
   def __init__(self, address, port, timeout = DEFAULT_TIMEOUT):
     self.address = address
@@ -40,34 +49,46 @@ class MineStat:
     self.max_players = None     # maximum player capacity
     self.latency = None         # ping time to server in milliseconds
 
-    # Connect to the server and get the data
-    byte_array = bytearray([0xFE, 0x01])
-    raw_data = None
-    data = []
-    try:
-      sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-      sock.settimeout(timeout)
-      start_time = datetime.now()
-      sock.connect((address, port))
-      self.latency = datetime.now() - start_time
-      self.latency = int(round(self.latency.total_seconds() * 1000))
-      sock.settimeout(None)
-      sock.send(byte_array)
-      raw_data = sock.recv(512)
-      sock.close()
-    except:
-      self.online = False
+    # TODO: Implement
+    #
+    # 1.: try to connect to MC 1.7+ SLP interface (JSON)
+    # 2.: try to connect to MC 1.6 SLP int
+    # 3.: 1.4/ 1.5 SLP
+    # 4.: b1.8 to 1.3
 
-    # Parse the received data
-    if raw_data is None or raw_data == '':
-      self.online = False
-    else:
-      data = raw_data.decode('cp437').split('\x00\x00\x00')
-      if data and len(data) >= self.NUM_FIELDS:
-        self.online = True
-        self.version = data[2].replace("\x00", "")
-        self.motd = str(data[3].encode('utf-8').replace(b"\x00", b""), 'utf-8')
-        self.current_players = data[4].replace("\x00", "")
-        self.max_players = data[5].replace("\x00", "")
-      else:
-        self.online = False
+  def json_query(self):
+    """
+    Minecraft 1.7+ SLP query, encoded JSON
+    See https://wiki.vg/Server_List_Ping#Current
+
+    TODO: Implement
+    """
+    pass
+
+  def query_1_6(self):
+    """
+    Minecraft 1.6 SLP query, extended legacy ping protocol
+
+    See https://wiki.vg/Server_List_Ping#1.6
+    :return:
+    """
+
+  def query_legacy(self):
+    """
+    Minecraft 1.4-1.5 SLP query, server response contains more info than beta SLP
+    See https://wiki.vg/Server_List_Ping#1.4_to_1.5
+
+  TODO: Implement
+    :return:
+    """
+    pass
+
+  def query_beta(self):
+    """
+    Minecraft Beta 1.8 to Release 1.3 SLP protocol
+    See https://wiki.vg/Server_List_Ping#Beta_1.8_to_1.3
+
+  TODO: Implement
+    :return:
+    """
+    pass

--- a/Python/minestat/__init__.py
+++ b/Python/minestat/__init__.py
@@ -62,7 +62,7 @@ class MineStat:
     self.timeout = timeout       # socket timeout
     self.slp_protocol = None     # Server List Ping protocol
 
-    # TODO: Next problem: IPv4/IPv6, multiple addresses
+    # Future improvement: IPv4/IPv6, multiple addresses
     # If a host has multiple IP addresses or a IPv4 and a IPv6 address,
     # socket.connect choses the first IPv4 address returned by DNS.
     # If a mc server is not available over IPv4, this failes as "offline".

--- a/Python/minestat/__init__.py
+++ b/Python/minestat/__init__.py
@@ -19,12 +19,18 @@
 import socket
 import struct
 from datetime import datetime
+from time import perf_counter, perf_counter_ns
 from enum import Enum
+from typing import Union
 
 
-class ConnectionStatus(Enum):
+class ConnStatus(Enum):
   """
-  TODO: Document
+Contains possible connection states.
+
+- `SUCCESS`: The specified SLP connection succeeded (Request & response parsing OK)
+- `CONNFAIL`: The socket to the server could not be established. Server offline, wrong hostname or port?
+- `TIMEOUT`:
   """
 
   SUCCESS = 0
@@ -35,26 +41,55 @@ class ConnectionStatus(Enum):
 
 class MineStat:
   VERSION = "2.0.0"             # MineStat version
-  NUM_FIELDS = 6                # number of values expected from server
-  NUM_FIELDS_BETA = 3           # number of values expected from a 1.8b/1.3 server
   DEFAULT_TIMEOUT = 5           # default TCP timeout in seconds
 
   def __init__(self, address, port, timeout = DEFAULT_TIMEOUT):
     self.address = address
     self.port = port
-    self.online = None          # online or offline?
-    self.version = None         # server version
-    self.motd = None            # message of the day
-    self.current_players = None # current number of players online
-    self.max_players = None     # maximum player capacity
-    self.latency = None         # ping time to server in milliseconds
+    self.online = None           # online or offline?
+    self.version = None          # server version
+    self.motd = None             # message of the day
+    self.current_players = None  # current number of players online
+    self.max_players = None      # maximum player capacity
+    self.latency = None          # ping time to server in milliseconds
+    self.timeout = timeout       # socket timeout
+
+    # TODO: Minecraft SRV resolution
+    # Maybe allow setting port to None, then internally try to resolve Minecraft SRV
+    # DNS entries?
+
+    # TODO: Next problem: IPv4/IPv6, multiple addresses
+    # If a host has multiple IP addresses or a IPv4 and a IPv6 address,
+    # socket.connect choses the first IPv4 address returned by DNS.
+    # If a mc server is not available over IPv4, this failes as "offline".
+    # Or in some environments, the DNS returns the external and the internal
+    # address, but from an internal client, only the internal address is reachable
+    # See https://docs.python.org/3/library/socket.html#socket.getaddrinfo
 
     # TODO: Implement
     #
     # 1.: try to connect to MC 1.7+ SLP interface (JSON)
-    # 2.: try to connect to MC 1.6 SLP int
-    # 3.: 1.4/ 1.5 SLP
-    # 4.: b1.8 to 1.3
+    # 2.: MC 1.6 SLP int - done
+    # 3.: 1.4/ 1.5 SLP - done
+    # 4.: b1.8 to 1.3 - done
+
+    # Minecraft 1.7+ (JSON SLP)
+    result = self.json_query()
+
+    # Minecraft 1.6 (extended legacy SLP)
+    if result is not ConnStatus.CONNFAIL \
+        and result is not ConnStatus.SUCCESS:
+      result = self.extended_legacy_query()
+
+    # Minecraft 1.4 & 1.5 (legacy SLP)
+    if result is not ConnStatus.CONNFAIL \
+        and result is not ConnStatus.SUCCESS:
+      result = self.legacy_query()
+
+    # Minecraft Beta 1.8 to Release 1.3 (beta SLP)
+    if result is not ConnStatus.CONNFAIL \
+        and result is not ConnStatus.SUCCESS:
+      self.beta_query()
 
   def json_query(self):
     """
@@ -63,32 +98,188 @@ class MineStat:
 
     TODO: Implement
     """
-    pass
+    return ConnStatus.UNKNOWN
 
-  def query_1_6(self):
+  def extended_legacy_query(self):
     """
-    Minecraft 1.6 SLP query, extended legacy ping protocol
+    Minecraft 1.6 SLP query, extended legacy ping protocol.
+    All modern servers are currently backwards compatible with this protocol.
 
     See https://wiki.vg/Server_List_Ping#1.6
     :return:
     """
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    sock.settimeout(self.timeout)
 
-  def query_legacy(self):
+    try:
+      start_time = perf_counter()
+      sock.connect((self.address, self.port))
+      self.latency = round((perf_counter() - start_time) * 1000)
+    except socket.timeout:
+      return ConnStatus.TIMEOUT
+    except:
+      return ConnStatus.CONNFAIL
+
+    # Send 0xFE as packet identifier,
+    # 0x01 as ping packet content
+    # 0xFA as packet identifier for a plugin message
+    # 0x00 0x0B as strlen of following string
+    req_data = bytearray([0xFE, 0x01, 0xFA, 0x00, 0x0B])
+    # the string 'MC|PingHost' as UTF-16BE encoded string
+    req_data += bytearray("MC|PingHost", "utf-16-be")
+    # 0xXX 0xXX byte count of rest of data, 7+len(serverhostname), as short
+    req_data += struct.pack(">h", 7 + (len(self.address) * 2))
+    # 0xXX [legacy] protocol version (before netty rewrite)
+    # Used here: 74 (MC 1.6.2)
+    req_data += bytearray([0x4A])
+    # strlen of serverhostname (big-endian short)
+    req_data += struct.pack(">h", len(self.address))
+    # the hostname of the server
+    req_data += bytearray(self.address, "utf-16-be")
+    # port of the server, as int (4 byte)
+    req_data += struct.pack(">i", self.port)
+
+    # Now send the contructed client requests
+    sock.send(req_data)
+
+    # Receive answer packet id (1 byte) and payload lengh (signed big-endian short; 2 byte)
+    raw_header = sock.recv(3)
+    # Extract payload length
+    content_len = struct.unpack(">xh", raw_header)[0]
+
+    # Receive full payload and close socket
+    payload_raw = bytearray(sock.recv(content_len * 2))
+    sock.close()
+
+    # Parse and save to object attributes
+    return self.__parse_legacy_payload(payload_raw)
+
+  def legacy_query(self):
     """
     Minecraft 1.4-1.5 SLP query, server response contains more info than beta SLP
+
     See https://wiki.vg/Server_List_Ping#1.4_to_1.5
 
-  TODO: Implement
-    :return:
+    :return: ConnStatus
     """
-    pass
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    sock.settimeout(self.timeout)
 
-  def query_beta(self):
+    try:
+      start_time = perf_counter()
+      sock.connect((self.address, self.port))
+      self.latency = round((perf_counter() - start_time) * 1000)
+    except socket.timeout:
+      return ConnStatus.TIMEOUT
+    except:
+      return ConnStatus.CONNFAIL
+
+    # Send 0xFE 0x01 as packet id
+    sock.send(bytearray([0xFE, 0x01]))
+    # Receive answer packet id (1 byte) and payload lengh (signed big-endian short; 2 byte)
+    raw_header = sock.recv(3)
+    # Extract payload length
+    content_len = struct.unpack(">xh", raw_header)[0]
+
+    # Receive full payload and close socket
+    payload_raw = bytearray(sock.recv(content_len * 2))
+    sock.close()
+
+    # Parse and save to object attributes
+    return self.__parse_legacy_payload(payload_raw)
+
+  def __parse_legacy_payload(self, payload_raw: Union[bytearray, bytes]) -> ConnStatus:
+    """
+    Internal helper method for parsing the legacy SLP payload (legacy and extended legacy).
+
+    :param payload_raw: The extracted legacy SLP payload as bytearray/bytes
+    """
+    # According to wiki.vg, beta, legacy and extended legacy use UTF-16BE as "payload" encoding
+    payload_str = payload_raw.decode('utf-16-be')
+
+    # This "payload" contains six fields delimited by a NUL character:
+    # - a fixed prefix '§1'
+    # - the protocol version
+    # - the server version
+    # - the MOTD
+    # - the online player count
+    # - the max player count
+    payload_list = payload_str.split('\x00')
+
+    # Check for count of string parts, expected is 6 for this protocol version
+    if len(payload_list) != 6:
+      return ConnStatus.UNKNOWN
+
+    # - a fixed prefix '§1'
+    # - the protocol version
+    # - the server version
+    self.version = payload_list[2]
+    # - the MOTD
+    self.motd = payload_list[3]
+    # - the online player count
+    self.current_players = int(payload_list[4])
+    # - the max player count
+    self.max_players = int(payload_list[5])
+
+    # If we got here, everything is in order
+    self.online = True
+    return ConnStatus.SUCCESS
+
+  def beta_query(self):
     """
     Minecraft Beta 1.8 to Release 1.3 SLP protocol
     See https://wiki.vg/Server_List_Ping#Beta_1.8_to_1.3
 
-  TODO: Implement
-    :return:
+    :return: ConnStatus
     """
-    pass
+
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    sock.settimeout(self.timeout)
+
+    try:
+      start_time = perf_counter()
+      sock.connect((self.address, self.port))
+      self.latency = round((perf_counter() - start_time) * 1000)
+    except socket.timeout:
+      return ConnStatus.TIMEOUT
+    except:
+      return ConnStatus.CONNFAIL
+
+    # Send 0xFE as packet id
+    sock.send(bytearray([0xFE]))
+    # Receive answer packet id (1 byte) and payload lengh (signed big-endian short; 2 byte)
+    raw_header = sock.recv(3)
+    # Extract payload length
+    content_len = struct.unpack(">xh", raw_header)[0]
+
+    # Receive full payload and close socket
+    payload_raw = bytearray(sock.recv(content_len * 2))
+    sock.close()
+
+    # According to wiki.vg, beta, legacy and extended legacy use UTF-16BE as "payload" encoding
+    payload_str = payload_raw.decode('utf-16-be')
+    # This "payload" contains three values:
+    # The MOTD, the max player count, and the online player count
+    payload_list = payload_str.split('§')
+
+    # Check for count of string parts, expected is 3 for this protocol version
+    # Note: We could check here if the list has the len() one, as that is most probably an error message.
+    # e.g. ['Protocol error']
+    if len(payload_list) < 3:
+      return ConnStatus.UNKNOWN
+
+    # The last value is the max player count
+    self.max_players = int(payload_list[-1])
+    # The second(-to-last) value is the online player count
+    self.current_players = int(payload_list[-2])
+    # The first value it the server MOTD
+    # This could contain '§' itself, thats the reason for the join here
+    self.motd = "§".join(payload_list[:-2])
+
+    # Set general version, as the protocol doesn't contain the server version
+    self.version = "<= 1.3"
+
+    # If we got here, everything is in order
+    self.online = True
+
+    return ConnStatus.SUCCESS

--- a/Python/setup.cfg
+++ b/Python/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = minestat 
-version = 1.0.1
+version = 2.0.0
 author = Lloyd Dilley
 author_email = devel@frag.land
 description = A Minecraft server status checker


### PR DESCRIPTION
In this PR I rewrote the Python module. The key features are:

## Key features
- Support for all SLP versions
   - `json`: MC 1.7+
   - `legacy_extended`: MC 1.6
   - `legacy`: MC 1.4 & 1.5
   - `beta`: MC beta1.8 - 1.3
- Included protocol documentation

I would love to hear some feedback for the changes.

Best regards,
MindSolve