### PR TITLE
Feature: [Python]: Replace slp_protocol strings with proper Enum

### DIFF
--- a/Python/minestat/__init__.py
+++ b/Python/minestat/__init__.py
@@ -33,6 +33,9 @@ Contains possible connection states.
 - `UNKNOWN`: The connection was established, but the server spoke an unknown/unsupported SLP protocol.
   """
 
+  def __str__(self):
+    return str(self.name)
+
   SUCCESS = 0
   """The specified SLP connection succeeded (Request & response parsing OK)"""
 
@@ -44,6 +47,79 @@ Contains possible connection states.
 
   UNKNOWN = -3
   """The connection was established, but the server spoke an unknown/unsupported SLP protocol."""
+
+
+class SlpProtocols(Enum):
+  """
+Contains possible SLP (Server List Ping) protocols.
+
+- `JSON`: The newest and currently supported SLP protocol.
+
+  Uses (wrapped) JSON as payload. Complex query, see `json_query()` for the protocol implementation.
+
+  *Available since Minecraft 1.7*
+- `EXTENDED_LEGACY`: The previous SLP protocol
+
+  Used by Minecraft 1.6, it is still supported by all newer server versions.
+  Complex query needed, see implementation `extended_legacy_query()` for full protocol details.
+
+  *Available since Minecraft 1.6*
+- `LEGACY`: The legacy SLP protocol.
+
+  Used by Minecraft 1.4 and 1.5, it is the first protocol to contain the server version number.
+  Very simple protocol call (2 byte), simple response decoding.
+  See `legacy_query()` for full implementation and protocol details.
+
+  *Available since Minecraft 1.4*
+- `BETA`: The first SLP protocol.
+
+  Used by Minecraft Beta 1.8 till Release 1.3, it is the first SLP protocol.
+  It contains very few details, no server version info, only MOTD, max- and online player counts.
+
+  *Available since Minecraft Beta 1.8*
+  """
+
+  def __str__(self):
+    return str(self.name)
+
+  JSON = 3
+  """
+  The newest and currently supported SLP protocol.
+  
+  Uses (wrapped) JSON as payload. Complex query, see `json_query()` for the protocol implementation.
+  
+  *Available since Minecraft 1.7*
+  """
+
+  EXTENDED_LEGACY = 2
+  """The previous SLP protocol
+  
+  Used by Minecraft 1.6, it is still supported by all newer server versions.
+  Complex query needed, see implementation `extended_legacy_query()` for full protocol details.
+  
+  *Available since Minecraft 1.6*
+  """
+
+  LEGACY = 1
+  """
+  The legacy SLP protocol.
+  
+  Used by Minecraft 1.4 and 1.5, it is the first protocol to contain the server version number.
+  Very simple protocol call (2 byte), simple response decoding.
+  See `legacy_query()` for full implementation and protocol details.
+  
+  *Available since Minecraft 1.4*  
+  """
+
+  BETA = 0
+  """
+  The first SLP protocol.
+  
+  Used by Minecraft Beta 1.8 till Release 1.3, it is the first SLP protocol.
+  It contains very few details, no server version info, only MOTD, max- and online player counts.
+  
+  *Available since Minecraft Beta 1.8*
+  """
 
 
 class MineStat:
@@ -159,7 +235,7 @@ class MineStat:
       return ConnStatus.UNKNOWN
 
     # Set protocol version
-    self.slp_protocol = "json"
+    self.slp_protocol = SlpProtocols.JSON
 
     # Parse and save to object attributes
     return self.__parse_json_payload(payload_raw)
@@ -279,7 +355,7 @@ class MineStat:
     sock.close()
 
     # Set protocol version
-    self.slp_protocol = "extended_legacy"
+    self.slp_protocol = SlpProtocols.EXTENDED_LEGACY
 
     # Parse and save to object attributes
     return self.__parse_legacy_payload(payload_raw)
@@ -323,7 +399,7 @@ class MineStat:
     sock.close()
 
     # Set protocol version
-    self.slp_protocol = "legacy"
+    self.slp_protocol = SlpProtocols.LEGACY
 
     # Parse and save to object attributes
     return self.__parse_legacy_payload(payload_raw)
@@ -404,7 +480,7 @@ class MineStat:
     sock.close()
 
     # Set protocol version
-    self.slp_protocol = "beta"
+    self.slp_protocol = SlpProtocols.BETA
 
     # According to wiki.vg, beta, legacy and extended legacy use UTF-16BE as "payload" encoding
     payload_str = payload_raw.decode('utf-16-be')

--- a/Python/minestat/__init__.py
+++ b/Python/minestat/__init__.py
@@ -126,7 +126,7 @@ class MineStat:
   VERSION = "2.0.1"             # MineStat version
   DEFAULT_TIMEOUT = 5           # default TCP timeout in seconds
 
-  def __init__(self, address, port, timeout = DEFAULT_TIMEOUT):
+  def __init__(self, address, port, timeout = DEFAULT_TIMEOUT, query_protocol: SlpProtocols = None):
     self.address = address
     self.port = port
     self.online = None           # online or offline?
@@ -145,6 +145,19 @@ class MineStat:
     # Or in some environments, the DNS returns the external and the internal
     # address, but from an internal client, only the internal address is reachable
     # See https://docs.python.org/3/library/socket.html#socket.getaddrinfo
+
+    # If the user wants a specific protocol, use only that.
+    if query_protocol:
+      if query_protocol is SlpProtocols.BETA:
+        self.beta_query()
+      elif query_protocol is SlpProtocols.LEGACY:
+        self.legacy_query()
+      elif query_protocol is SlpProtocols.EXTENDED_LEGACY:
+        self.extended_legacy_query()
+      elif query_protocol is SlpProtocols.JSON:
+        self.json_query()
+
+      return
 
     # Minecraft 1.7+ (JSON SLP)
     result = self.json_query()

--- a/Python/minestat/__init__.py
+++ b/Python/minestat/__init__.py
@@ -123,7 +123,7 @@ Contains possible SLP (Server List Ping) protocols.
 
 
 class MineStat:
-  VERSION = "2.0.1"             # MineStat version
+  VERSION = "2.1.0"             # MineStat version
   DEFAULT_TIMEOUT = 5           # default TCP timeout in seconds
 
   def __init__(self, address, port, timeout = DEFAULT_TIMEOUT, query_protocol: SlpProtocols = None):

--- a/Python/setup.cfg
+++ b/Python/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = minestat 
-version = 2.0.1
+version = 2.1.0
 author = Lloyd Dilley
 author_email = devel@frag.land
 description = A Minecraft server status checker


### PR DESCRIPTION
## Proposed Changes
- Added new Enum `SlpProtocols`, which contains a list of possible SLP protocols
- Replace the `Minestat.slp_protocol` string property with a properly documented Enum attribute
- Added a `__str__()` override to the Enums, to be compatible with previous documentation (returns the name of the property, not the full `<enumname>.<propertyname>`). This allows the Enum attributes to be used like strings.
- Bumped version from `2.0.1` to `2.1.0`

Additionally, this PR adds a new _**optional**_ parameter to the MineStat class: `query_protocol`.
This allows a user to force a specific SLP protocol, for example to improve the response time for old MC versions.
This could also be helpful for debugging a specific protocol implementation.