### PR TITLE
Feature: [C#] Add full SLP protocol support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,10 +6,8 @@ bin/
 blib/
 build/
 dist/
-Example.exe
 Makefile
 Minecraft-ServerStatus-*.tar.gz
-MineStat.dll
 minestat.egg-info/
 MYMETA.json
 MYMETA.yml
@@ -20,3 +18,7 @@ tests/
 
 # Ignore Python virtual environments
 venv/
+
+# Ignore all compiled c# files
+*.exe
+*.dll

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ matrix:
   include:
     - language: csharp
       script:
-        - cd CSharp && mcs Example.cs MineStat/MineStat.cs
+        - cd CSharp && mcs -reference:System.Runtime.Serialization.dll -reference:System.Xml.Linq.dll Example.cs MineStat/MineStat.cs
 
     - language: go
       #go_import_path: github.com/FragLand/minestat

--- a/CSharp/Example.cs
+++ b/CSharp/Example.cs
@@ -6,12 +6,13 @@ class Example
   public static void Main()
   {
     MineStat ms = new MineStat("minecraft.frag.land", 25565);
-    Console.WriteLine("Minecraft server status of {0} on port {1}:", ms.GetAddress(), ms.GetPort());
-    if(ms.IsServerUp())
+    Console.WriteLine("Minecraft server status of {0} on port {1}:", ms.Address, ms.Port);
+    if(ms.ServerUp)
     {
-      Console.WriteLine("Server is online running version {0} with {1} out of {2} players.", ms.GetVersion(), ms.GetCurrentPlayers(), ms.GetMaximumPlayers());
-      Console.WriteLine("Message of the day: {0}", ms.GetMotd());
-      Console.WriteLine("Latency: {0}ms", ms.GetLatency());
+      Console.WriteLine("Server is online running version {0} with {1} out of {2} players.",
+        ms.Version, ms.CurrentPlayers, ms.MaximumPlayers);
+      Console.WriteLine("Message of the day: {0}", ms.Motd);
+      Console.WriteLine("Latency: {0}ms", ms.Latency);
     }
     else
       Console.WriteLine("Server is offline!");

--- a/CSharp/Example.cs
+++ b/CSharp/Example.cs
@@ -5,7 +5,7 @@ class Example
 {
   public static void Main()
   {
-    MineStat ms = new MineStat("gameserv.ng.fx3.eu", 25566);
+    MineStat ms = new MineStat("minecraft.frag.land", 25565);
     Console.WriteLine("Minecraft server status of {0} on port {1}:", ms.Address, ms.Port);
     if(ms.ServerUp)
     {

--- a/CSharp/Example.cs
+++ b/CSharp/Example.cs
@@ -5,7 +5,7 @@ class Example
 {
   public static void Main()
   {
-    MineStat ms = new MineStat("minecraft.frag.land", 25565);
+    MineStat ms = new MineStat("gameserv.ng.fx3.eu", 25566);
     Console.WriteLine("Minecraft server status of {0} on port {1}:", ms.Address, ms.Port);
     if(ms.ServerUp)
     {
@@ -13,6 +13,7 @@ class Example
         ms.Version, ms.CurrentPlayers, ms.MaximumPlayers);
       Console.WriteLine("Message of the day: {0}", ms.Motd);
       Console.WriteLine("Latency: {0}ms", ms.Latency);
+      Console.WriteLine("Connected using SLP protocol '{0}'", ms.Protocol.ToString());
     }
     else
       Console.WriteLine("Server is offline!");

--- a/CSharp/MineStat/MineStat.cs
+++ b/CSharp/MineStat/MineStat.cs
@@ -1,6 +1,6 @@
 /*
  * MineStat.cs - A Minecraft server status checker
- * Copyright (C) 2014 Lloyd Dilley
+ * Copyright (C) 2014-2021 Lloyd Dilley, 2021 Felix Ern (MindSolve)
  * http://www.dilley.me/
  *
  * This program is free software; you can redistribute it and/or modify
@@ -22,74 +22,207 @@ using System;
 using System.Net.Sockets;
 using System.Text;
 using System.Diagnostics;
+using System.IO;
+using System.Linq;
 
 namespace MineStatLib
 {
   public class MineStat
   {
-    public const string MineStatVersion = "1.0.1"; 
-    const ushort dataSize = 512;  // this will hopefully suffice since the MotD should be <=59 characters
-    const ushort numFields = 6;   // number of values expected from server
-    const int defaultTimeout = 5; // default TCP timeout in seconds
+    public const string MineStatVersion = "2.0.0";
+    private const int DefaultTimeout = 5; // default TCP timeout in seconds
 
     public string Address { get; set; }
     public ushort Port { get; set; }
     public int Timeout { get; set; }
     public string Motd { get; set; }
     public string Version { get; set; }
-    public string CurrentPlayers { get; set; }
-    public string MaximumPlayers { get; set; }
+    public string CurrentPlayers => Convert.ToString(CurrentPlayersInt);
+    public int CurrentPlayersInt { get; set; }
+    public string MaximumPlayers => Convert.ToString(MaximumPlayersInt);
+    public int MaximumPlayersInt { get; set; }
     public bool ServerUp { get; set; }
     public long Latency { get; set; }
+    public SlpProtocol Protocol { get; set; }
 
-    public MineStat(string address, ushort port, int timeout = defaultTimeout)
+    /// <summary>
+    /// TODO: Document
+    /// </summary>
+    /// <param name="address">Address (hostname or IP) of Minecraft server to connect to</param>
+    /// <param name="port">Port to connect to on the address</param>
+    /// <param name="timeout">Timeout in seconds</param>
+    public MineStat(string address, ushort port, int timeout = DefaultTimeout)
     {
-      var rawServerData = new byte[dataSize];
-
       Address = address;
       Port = port;
-      Timeout = timeout * 1000;   // milliseconds
+      Timeout = timeout;
+      
+      /*
+       * 1. Try JSON protocol
+       * 2. Try extended legacy protocol
+       * 3. Try legacy protocol
+       * 4. Try beta protocol
+       */
+
+      var result = QueryWithJsonProtocol();
+
+      if (result != ConnStatus.Connfail && result != ConnStatus.Success)
+        result = QueryWithExtendedLegacyProtocol();
+
+      if (result != ConnStatus.Connfail && result != ConnStatus.Success)
+        result = QueryWithLegacyProtocol();
+
+      if (result != ConnStatus.Connfail && result != ConnStatus.Success)
+        QueryWithBetaProtocol();
+      
+    }
+
+    public ConnStatus QueryWithJsonProtocol()
+    {
+      // TODO: Implement
+      return ParseJsonProtocolPayload(null);
+    }
+
+    private ConnStatus ParseJsonProtocolPayload(byte[] rawPayload)
+    {
+      // TODO: Implement
+      return ConnStatus.Unknown;
+    }
+
+    public ConnStatus QueryWithExtendedLegacyProtocol()
+    {
+      // TODO: Implement
+      return ParseLegacyProtocol(null);
+    }
+
+    public ConnStatus QueryWithLegacyProtocol()
+    {
+      // TODO: Implement
+      
+      // var rawServerData = new byte[dataSize];
+      //
+      // Address = address;
+      // Port = port;
+      // Timeout = timeout * 1000;   // milliseconds
+      //
+      // try
+      // {
+      //   var stopWatch = new Stopwatch();
+      //   var tcpclient = new TcpClient{ReceiveTimeout = Timeout};
+      //   stopWatch.Start();
+      //   tcpclient.Connect(address, port);
+      //   stopWatch.Stop();
+      //   Latency = stopWatch.ElapsedMilliseconds;
+      //   var stream = tcpclient.GetStream();
+      //   var payload = new byte[] { 0xFE, 0x01 };
+      //   stream.Write(payload, 0, payload.Length);
+      //   stream.Read(rawServerData, 0, dataSize);
+      //   tcpclient.Close();
+      // }
+      // catch(Exception)
+      // {
+      //   ServerUp = false;
+      //   return;
+      // }
+      //
+      // if(rawServerData == null || rawServerData.Length == 0)
+      // {
+      //   ServerUp = false;
+      // }
+      // else
+      // {
+      //   var serverData = Encoding.Unicode.GetString(rawServerData).Split("\u0000\u0000\u0000".ToCharArray());
+      //   if(serverData != null && serverData.Length >= numFields)
+      //   {
+      //     ServerUp = true;
+      //     Version = serverData[2];
+      //     Motd = serverData[3];
+      //     CurrentPlayers = serverData[4];
+      //     MaximumPlayers = serverData[5];
+      //   }
+      //   else
+      //   {
+      //     ServerUp = false;
+      //   }
+      // }
+      
+      return ParseLegacyProtocol(null);
+    }
+
+    private ConnStatus ParseLegacyProtocol(byte[] rawPayload)
+    {
+      // TODO: Implement
+      return ConnStatus.Unknown;
+    }
+
+    public ConnStatus QueryWithBetaProtocol()
+    {
+      var tcpclient = new TcpClient {ReceiveTimeout = Timeout * 1000};
 
       try
       {
         var stopWatch = new Stopwatch();
-        var tcpclient = new TcpClient{ReceiveTimeout = Timeout};
         stopWatch.Start();
-        tcpclient.Connect(address, port);
+        tcpclient.Connect(Address, Port);
         stopWatch.Stop();
         Latency = stopWatch.ElapsedMilliseconds;
-        var stream = tcpclient.GetStream();
-        var payload = new byte[] { 0xFE, 0x01 };
-        stream.Write(payload, 0, payload.Length);
-        stream.Read(rawServerData, 0, dataSize);
-        tcpclient.Close();
       }
       catch(Exception)
       {
         ServerUp = false;
-        return;
+        return ConnStatus.Connfail;
+      }
+      
+      // Send empty packet with id 0xFE
+      var stream = tcpclient.GetStream();
+      var betaPingPacket = new byte[] { 0xFE };
+      stream.Write(betaPingPacket, 0, betaPingPacket.Length);
+
+      var responsePacketHeader = new byte[3];
+      stream.Read(responsePacketHeader, 0, 3);
+
+      // Check for response packet id
+      if (responsePacketHeader[0] != 0xFF)
+      {
+        return ConnStatus.Unknown;
       }
 
-      if(rawServerData == null || rawServerData.Length == 0)
-      {
-        ServerUp = false;
-      }
-      else
-      {
-        var serverData = Encoding.Unicode.GetString(rawServerData).Split("\u0000\u0000\u0000".ToCharArray());
-        if(serverData != null && serverData.Length >= numFields)
-        {
-          ServerUp = true;
-          Version = serverData[2];
-          Motd = serverData[3];
-          CurrentPlayers = serverData[4];
-          MaximumPlayers = serverData[5];
-        }
-        else
-        {
-          ServerUp = false;
-        }
-      }
+      // Change Endianness to Big-Endian, if needed
+      if (BitConverter.IsLittleEndian)
+        Array.Reverse(responsePacketHeader);
+      // Get Payload string length (ToUInt16 ignores everything after the first 2 bytes)
+      var payloadLength = BitConverter.ToUInt16(responsePacketHeader, 0);
+
+      // Receive payload
+      var payload = new byte[payloadLength * 2];
+      stream.Read(payload, 0, payloadLength*2);
+
+      // Close socket
+      tcpclient.Close();
+        
+      // Decode byte[] as UTF16BE
+      var payloadString = Encoding.BigEndianUnicode.GetString(payload, 0, payload.Length);
+
+      var payloadArray = payloadString.Split('§');
+        
+      // Max player count is the last element
+      MaximumPlayersInt = Convert.ToInt32(payloadArray[payloadArray.Length-1]);
+        
+      // Current player count is second-to-last element
+      CurrentPlayersInt = Convert.ToInt32(payloadArray[payloadArray.Length-2]);
+        
+      // Motd is first element, but may contain 'section sign' (the delimiter)
+      Motd = String.Join("§", payloadArray.Take(payloadArray.Length - 2).ToArray());
+      
+      // If we got here, everything is in order
+      ServerUp = true;
+      Protocol = SlpProtocol.Beta;
+      
+      // This protocol does not provide the server version.
+      Version = "<= 1.3";
+      
+      
+      return ConnStatus.Success;
     }
 
     #region Obsolete
@@ -151,7 +284,7 @@ namespace MineStatLib
     [Obsolete]
     public void SetCurrentPlayers(string currentPlayers)
     {
-      CurrentPlayers = currentPlayers;
+      CurrentPlayersInt = Convert.ToInt32(currentPlayers);
     }
 
     [Obsolete]
@@ -163,7 +296,7 @@ namespace MineStatLib
     [Obsolete]
     public void SetMaximumPlayers(string maximumPlayers)
     {
-      MaximumPlayers = maximumPlayers;
+      MaximumPlayersInt = Convert.ToInt32(maximumPlayers);
     }
 
     [Obsolete]
@@ -186,4 +319,89 @@ namespace MineStatLib
 
     #endregion
   }
+  
+  /// <summary>
+  /// Contains possible connection states.
+  /// </summary>
+  /// <list type="bullet">
+  ///   <item>
+  ///     <term>Success: </term>
+  ///     <description>The specified SLP connection succeeded (Request and response parsing OK)</description>
+  ///   </item>
+  ///   <item>
+  ///     <term>Connfail: </term>
+  ///     <description>The socket to the server could not be established. (Server offline, wrong hostname or port?)</description>
+  ///   </item>
+  ///   <item>
+  ///     <term>Timeout: </term>
+  ///     <description>The connection timed out. (Server under too much load? Firewall rules OK?)</description>
+  ///   </item>
+  ///   <item>
+  ///     <term>Unknown: </term>
+  ///     <description>The connection was established, but the server spoke an unknown/unsupported SLP protocol.</description>
+  ///   </item>
+  /// </list>
+  public enum ConnStatus
+  {
+    /// <summary>
+    /// The specified SLP connection succeeded (Request and response parsing OK)
+    /// </summary>
+    Success,
+    
+    /// <summary>
+    /// The socket to the server could not be established. (Server offline, wrong hostname or port?)
+    /// </summary>
+    Connfail,
+    
+    /// <summary>
+    /// The connection timed out. (Server under too much load? Firewall rules OK?)
+    /// </summary>
+    Timeout,
+    
+    /// <summary>
+    /// The connection was established, but the server spoke an unknown/unsupported SLP protocol.
+    /// </summary>
+    Unknown
+  }
+
+  /// <summary>
+  /// Enum of possible SLP (Server List Ping) protocol versions.
+  /// </summary>
+  public enum SlpProtocol
+  {
+    /// <summary>
+    /// The newest and currently supported SLP protocol.<br/>
+    /// Uses (wrapped) JSON as payload. Complex query, see above <see cref="MineStat.QueryWithJsonProtocol"/>
+    /// for the protocol implementation. <br/>
+    /// <i>Available since Minecraft 1.7.</i>
+    /// </summary>
+    Json,
+    
+    /// <summary>
+    /// The previous SLP protocol.<br/>
+    /// Used by Minecraft 1.6, it is still supported by all newer server versions.
+    /// Complex query needed, see implementation <see cref="MineStat.QueryWithExtendedLegacyProtocol"/> for all protocol
+    /// details.<br/>
+    /// <i>Available since Minecraft 1.6</i>
+    /// </summary>
+    ExtendedLegacy,
+    
+    /// <summary>
+    /// The legacy SLP protocol.<br/>
+    /// Used by Minecraft 1.4 and 1.5, it is the first protocol to contain the server version number.
+    /// Very simple protocol call (2 byte), simple response decoding.
+    /// See <see cref="MineStat.QueryWithLegacyProtocol"/> for full implementation and protocol details.<br/>
+    /// <i>Available since Minecraft 1.4</i>
+    /// </summary>
+    Legacy,
+    
+    /// <summary>
+    /// The first SLP protocol.<br/>
+    /// Used by Minecraft Beta 1.8 till Release 1.3, it is the first SLP protocol.
+    /// It contains very few details, no server version info, only MOTD, max- and online player counts.<br/>
+    /// <i>Available since Minecraft Beta 1.8</i>
+    /// </summary>
+    Beta
+  }
+  
 }

--- a/CSharp/MineStat/MineStat.cs
+++ b/CSharp/MineStat/MineStat.cs
@@ -240,7 +240,6 @@ namespace MineStatLib
         
         // the max player count
         MaximumPlayersInt = Convert.ToInt16(root.XPathSelectElement("//players/max")?.Value);
-
       }
       catch (Exception)
       {

--- a/CSharp/MineStat/MineStat.csproj
+++ b/CSharp/MineStat/MineStat.csproj
@@ -10,6 +10,7 @@
     <RootNamespace>MineStatLib</RootNamespace>
     <AssemblyName>MineStat</AssemblyName>
     <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
+    <TargetFramework>net46</TargetFramework>
     <FileAlignment>512</FileAlignment>
     <Deterministic>true</Deterministic>
   </PropertyGroup>
@@ -33,9 +34,12 @@
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Data" />
+    <Reference Include="System.Xml" />
+    <Reference Include="System.Xml.Linq" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="MineStat.cs" />

--- a/CSharp/MineStat/MineStat.nuspec
+++ b/CSharp/MineStat/MineStat.nuspec
@@ -12,7 +12,6 @@
     <copyright>$copyright$</copyright>
     <tags>Minecraft status checker library</tags>
     <dependencies>
-      <group targetFramework=".NETFramework4.6" />
     </dependencies>
     <frameworkAssemblies>
       <frameworkAssembly assemblyName="System.Core" targetFramework="net46" />

--- a/CSharp/MineStat/Properties/AssemblyInfo.cs
+++ b/CSharp/MineStat/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.1.0")]
-[assembly: AssemblyFileVersion("1.0.1.0")]
+[assembly: AssemblyVersion("2.0.0.0")]
+[assembly: AssemblyFileVersion("2.0.0.0")]


### PR DESCRIPTION
As this is the first time writing C#, I would love some constructive feedback!
The general layout is based on the PHP, Python and Java implementations.

### Proposed Changes (C# specific)
- Added the `beta`, `extended legacy` and `json` SLP protocols
- Rewrote the `legacy` protocol implementation
- Added enums for protocol and connection status
- Added optional "force specific protocol" parameter
- Added dependency on `Newtonsoft.Json` for `json` SLP protocol [!]
- Bumped version to 2.0

### Proposed Changes (Documentation)
- Edited the example to use class variable accessors (not the deprecated getter methods)

### Proposed Changes (other)
- Added `.exe` and `.dll` files to `.gitignore` to ignore all binary executables, not only Example and Minestat files.