### PR TITLE
Python: Fix infinite hang on closed connections

### DIFF
--- a/Python/minestat/__init__.py
+++ b/Python/minestat/__init__.py
@@ -368,7 +368,7 @@ class MineStat:
       packet_id = self._recv_exact(sock, 1)
 
       # Check packet id (should be "kick packet 0xFF")
-      if packet_id != 0xFF:
+      if packet_id[0] != 0xFF:
         return ConnStatus.UNKNOWN
 
       # Receive payload lengh (signed big-endian short; 2 byte)

--- a/Python/minestat/__init__.py
+++ b/Python/minestat/__init__.py
@@ -250,7 +250,7 @@ class MineStat:
 
     except socket.timeout:
       return ConnStatus.TIMEOUT
-    except ConnectionResetError or ConnectionAbortedError:
+    except (ConnectionResetError, ConnectionAbortedError):
       return ConnStatus.UNKNOWN
     except OSError:
       return ConnStatus.CONNFAIL
@@ -368,6 +368,8 @@ class MineStat:
       raw_header = self._recv_exact(sock, 3)
     except socket.timeout:
       return ConnStatus.TIMEOUT
+    except (ConnectionResetError, ConnectionAbortedError):
+      return ConnStatus.UNKNOWN
     except OSError:
       return ConnStatus.CONNFAIL
 
@@ -416,6 +418,8 @@ class MineStat:
       raw_header = self._recv_exact(sock, 3)
     except socket.timeout:
       return ConnStatus.TIMEOUT
+    except (ConnectionAbortedError, ConnectionResetError):
+      return ConnStatus.UNKNOWN
     except OSError:
       return ConnStatus.CONNFAIL
 
@@ -501,6 +505,8 @@ class MineStat:
       raw_header = self._recv_exact(sock, 3)
     except socket.timeout:
       return ConnStatus.TIMEOUT
+    except (ConnectionResetError, ConnectionAbortedError):
+      return ConnStatus.UNKNOWN
     except OSError:
       return ConnStatus.CONNFAIL
 

--- a/Python/minestat/__init__.py
+++ b/Python/minestat/__init__.py
@@ -120,7 +120,7 @@ Contains possible SLP (Server List Ping) protocols.
   """
 
 class MineStat:
-  VERSION = "2.1.1"             # MineStat version
+  VERSION = "2.1.2"             # MineStat version
   DEFAULT_TIMEOUT = 5           # default TCP timeout in seconds
 
   def __init__(self, address, port, timeout = DEFAULT_TIMEOUT, query_protocol: SlpProtocols = None):

--- a/Python/minestat/__init__.py
+++ b/Python/minestat/__init__.py
@@ -542,6 +542,7 @@ class MineStat:
   def _recv_exact(sock: socket.socket, size: int) -> bytearray:
     """
     Helper function for receiving a specific amount of data. Works around the problems of `socket.recv`.
+    Throws a ConnectionAbortedError if the connection was closed while waiting for data.
 
     :param sock: Open socket to receive data from
     :param size: Amount of bytes of data to receive
@@ -550,6 +551,12 @@ class MineStat:
     data = bytearray()
 
     while len(data) < size:
-      data += bytearray(sock.recv(size - len(data)))
+      temp_data = bytearray(sock.recv(size - len(data)))
+
+      # If the connection was closed, `sock.recv` returns an empty string
+      if not temp_data:
+        raise ConnectionAbortedError
+
+      data += temp_data
 
     return data

--- a/Python/setup.cfg
+++ b/Python/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = minestat 
-version = 2.1.1
+version = 2.1.2
 author = Lloyd Dilley
 author_email = minecraft@frag.land
 description = A Minecraft server status checker


### PR DESCRIPTION
## Proposed Main Changes
- Fixed infinite hang in `_recv_exact()` if the connection is closed

### Additional Changes
- Added more (and better) error handling and data checking
- Bumped version to `2.1.2`

This PR closes issue #79.