### PR TITLE
C#: Made motd parsing and sockets more resilient

### DIFF
--- a/CSharp/MineStat/MineStat.cs
+++ b/CSharp/MineStat/MineStat.cs
@@ -608,6 +608,12 @@ namespace MineStatLib
         var tempBuffer = new byte[size - totalReadBytes];
         var readBytes = stream.Read(tempBuffer, 0, size - totalReadBytes);
 
+        // Socket is closed
+        if (readBytes == 0)
+        {
+          throw new IOException();
+        }
+
         resultBuffer.AddRange(tempBuffer.Take(readBytes));
         totalReadBytes += readBytes;
       } while (totalReadBytes < size);

--- a/CSharp/MineStat/MineStat.cs
+++ b/CSharp/MineStat/MineStat.cs
@@ -232,13 +232,21 @@ namespace MineStatLib
         Version = root.XPathSelectElement("//version/name")?.Value;
         
         // the MOTD
-        Motd = root.XPathSelectElement("//description/text")?.Value;
+        var descriptionElement = root.XPathSelectElement("//description");
+        if (descriptionElement != null && descriptionElement.Attribute(XName.Get("type"))?.Value == "string")
+        {
+          Motd = descriptionElement.Value;
+        }
+        else if (root.XPathSelectElement("//description/text") != null)
+        {
+          Motd = root.XPathSelectElement("//description/text")?.Value;
+        }
         
         // the online player count
-        CurrentPlayersInt = Convert.ToInt16(root.XPathSelectElement("//players/online")?.Value);
+        CurrentPlayersInt = Convert.ToInt32(root.XPathSelectElement("//players/online")?.Value);
         
         // the max player count
-        MaximumPlayersInt = Convert.ToInt16(root.XPathSelectElement("//players/max")?.Value);
+        MaximumPlayersInt = Convert.ToInt32(root.XPathSelectElement("//players/max")?.Value);
       }
       catch (Exception)
       {


### PR DESCRIPTION
This PR is basically identical with PR #78, but this time for the C# implementation (and without the infinite loop 😉).

## Proposed Changes
- Fixes a race condition with `NetworkStream.Read()`, where not all data would have been received if the server is slow or the content is large (e.g. favicon in `json` SLP).
- Fixes #77: motd extraction for `json` SLP protocol, if "description" is not an object, but a string (e.g. Hypixel)
- Fixes endless loop if a socket was closed, but more data was expected (in `NetStreamReadExact()`)
- Adds more error-checking to detect wrong protocol tries earlier (response packet size), and additional error handling in `RequestWithBetaProtocol()`)

### Notes:
- In my testing, *"sometimes"* running the code multiple times resulted in different outcomes (`server offline` vs. `online with json`). I am not sure whether there is some kind of race condition in the code, or whether Hypixel (the test target) doesn't like repeated tries with wrong protocols (aka. our protocol detection).
- Somehow, the implementation of `NetStreamReadExact()` feels suboptimal. I would greatly appreciate suggestions for improvement.