### PR TITLE
Python: Proper JSON MOTD parsing

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -192,6 +192,7 @@ print('Minecraft server status of %s on port %d:' % (ms.address, ms.port))
 if ms.online:
   print('Server is online running version %s with %s out of %s players.' % (ms.version, ms.current_players, ms.max_players))
   print('Message of the day: %s' % ms.motd)
+  print('Message of the day without formatting: %s' % ms.stripped_motd)
   print('Latency: %sms' % ms.latency)
   print('Connected using protocol: %s' % ms.slp_protocol)
 else:

--- a/Python/README.md
+++ b/Python/README.md
@@ -17,6 +17,7 @@ print('Minecraft server status of %s on port %d:' % (ms.address, ms.port))
 if ms.online:
   print('Server is online running version %s with %s out of %s players.' % (ms.version, ms.current_players, ms.max_players))
   print('Message of the day: %s' % ms.motd)
+  print('Message of the day without formatting: %s' % ms.stripped_motd)
   print('Latency: %sms' % ms.latency)
   print('Connected using protocol: %s' % ms.slp_protocol)
 else:

--- a/Python/example.py
+++ b/Python/example.py
@@ -7,6 +7,7 @@ print('Minecraft server status of %s on port %d:' % (ms.address, ms.port))
 if ms.online:
   print('Server is online running version %s with %s out of %s players.' % (ms.version, ms.current_players, ms.max_players))
   print('Message of the day: %s' % ms.motd)
+  print('Message of the day without formatting: %s' % ms.stripped_motd)
   print('Latency: %sms' % ms.latency)
   print('Connected using protocol: %s' % ms.slp_protocol)
 else:

--- a/Python/minestat/__init__.py
+++ b/Python/minestat/__init__.py
@@ -18,6 +18,7 @@
 import json
 import socket
 import struct
+import re
 from time import perf_counter
 from enum import Enum
 from typing import Union
@@ -128,7 +129,8 @@ class MineStat:
     self.port = port
     self.online = None           # online or offline?
     self.version = None          # server version
-    self.motd = None             # message of the day
+    self.motd = None             # message of the day, unchanged server response (including formatting codes/JSON)
+    self.stripped_motd = None    # message of the day, stripped of all formatting ("human-readable")
     self.current_players = None  # current number of players online
     self.max_players = None      # maximum player capacity
     self.latency = None          # ping time to server in milliseconds
@@ -177,6 +179,28 @@ class MineStat:
     # Minecraft 1.7+ (JSON SLP)
     if result is not ConnStatus.CONNFAIL:
       self.json_query()
+
+  @staticmethod
+  def motd_strip_formatting(raw_motd: Union[str, dict]) -> str:
+    """
+    Function for stripping all formatting codes from a motd. Supports Json Chat components (as dict) and
+    the legacy formatting codes.
+
+    :param raw_motd: The raw MOTD, either as a string or dict (from "json.loads()")
+    """
+    stripped_motd = ""
+
+    if type(raw_motd) is str:
+      stripped_motd = re.sub(r"§.", "", raw_motd)
+
+    elif type(raw_motd) is dict:
+      stripped_motd = raw_motd.get("text", "")
+
+      if raw_motd.get("extra"):
+        for sub in raw_motd["extra"]:
+          stripped_motd += MineStat.motd_strip_formatting(sub)
+
+    return stripped_motd
 
   def json_query(self):
     """
@@ -278,10 +302,12 @@ class MineStat:
     # Now that we have the status object, set all fields
     self.version = payload_obj["version"]["name"]
 
+    # The motd might be a string directly, not a json object
     if type(payload_obj["description"]) is str:
-        self.motd = payload_obj["description"]
-    elif type(payload_obj["description"]) is dict and "text" in payload_obj["description"]:
-        self.motd = payload_obj["description"]["text"]
+      self.motd = payload_obj["description"]
+    else:
+      self.motd = json.dumps(payload_obj["description"])
+    self.stripped_motd = self.motd_strip_formatting(payload_obj["description"])
 
     self.max_players = payload_obj["players"]["max"]
     self.current_players = payload_obj["players"]["online"]
@@ -478,6 +504,7 @@ class MineStat:
     self.version = payload_list[2]
     # - the MOTD
     self.motd = payload_list[3]
+    self.stripped_motd = self.motd_strip_formatting(payload_list[3])
     # - the online player count
     self.current_players = int(payload_list[4])
     # - the max player count
@@ -553,6 +580,7 @@ class MineStat:
     # The first value it the server MOTD
     # This could contain '§' itself, thats the reason for the join here
     self.motd = "§".join(payload_list[:-2])
+    self.stripped_motd = self.motd_strip_formatting("§".join(payload_list[:-2]))
 
     # Set general version, as the protocol doesn't contain the server version
     self.version = ">=1.8b/1.3"

--- a/Python/minestat/__init__.py
+++ b/Python/minestat/__init__.py
@@ -120,7 +120,7 @@ Contains possible SLP (Server List Ping) protocols.
   """
 
 class MineStat:
-  VERSION = "2.1.2"             # MineStat version
+  VERSION = "2.2.0"             # MineStat version
   DEFAULT_TIMEOUT = 5           # default TCP timeout in seconds
 
   def __init__(self, address, port, timeout = DEFAULT_TIMEOUT, query_protocol: SlpProtocols = None):

--- a/Python/minestat/__init__.py
+++ b/Python/minestat/__init__.py
@@ -190,10 +190,10 @@ class MineStat:
     """
     stripped_motd = ""
 
-    if type(raw_motd) is str:
+    if isinstance(raw_motd, str):
       stripped_motd = re.sub(r"§.", "", raw_motd)
 
-    elif type(raw_motd) is dict:
+    elif isinstance(raw_motd, dict):
       stripped_motd = raw_motd.get("text", "")
 
       if raw_motd.get("extra"):
@@ -303,7 +303,7 @@ class MineStat:
     self.version = payload_obj["version"]["name"]
 
     # The motd might be a string directly, not a json object
-    if type(payload_obj["description"]) is str:
+    if isinstance(payload_obj["description"], str):
       self.motd = payload_obj["description"]
     else:
       self.motd = json.dumps(payload_obj["description"])

--- a/Python/setup.cfg
+++ b/Python/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = minestat 
-version = 2.1.2
+version = 2.2.0
 author = Lloyd Dilley
 author_email = minecraft@frag.land
 description = A Minecraft server status checker


### PR DESCRIPTION
This PR adds proper MOTD parsing support for the **Python** variant, see issue #84.

## Proposed Changes
### Main changes
- Added Json MOTD parsing support for the `json` SLP protocol
- Added the new attribute `stripped_motd`, which contains a "human-readable" motd (without any formatting)
- Fixed the behaviour of the attribute `motd`, to always contain the unmodified server motd (including all formatting codes/JSON)

### Other changes
- Updated the examples with the new attribute
- Bumped the version to `2.2.0`