### PR TITLE
[Java] Feature: MOTD format stripping / bungeecord fixes

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -76,6 +76,7 @@ class Example
     {
      System.out.println("Server is online running version " + ms.getVersion() + " with " + ms.getCurrentPlayers() + " out of " + ms.getMaximumPlayers() + " players.");
      System.out.println("Message of the day: " + ms.getMotd());
+     System.out.println("Message of the day without formatting: " + ms.getStrippedMotd());
      System.out.println("Latency: " + ms.getLatency() + "ms");
      System.out.println("Connected using protocol: " + ms.getRequestType());
     }

--- a/Java/Example.java
+++ b/Java/Example.java
@@ -10,6 +10,7 @@ class Example
     {
       System.out.println("Server is online running version " + ms.getVersion() + " with " + ms.getCurrentPlayers() + " out of " + ms.getMaximumPlayers() + " players.");
       System.out.println("Message of the day: " + ms.getMotd());
+      System.out.println("Message of the day without formatting: " + ms.getStrippedMotd());
       System.out.println("Latency: " + ms.getLatency() + "ms");
       System.out.println("Connected using protocol: " + ms.getRequestType());
     }

--- a/Java/me/dilley/MineStat.java
+++ b/Java/me/dilley/MineStat.java
@@ -30,7 +30,7 @@ import java.net.*;
 
 public class MineStat
 {
-  public static final String VERSION = "2.0.0"; // MineStat version
+  public static final String VERSION = "2.1.0"; // MineStat version
   public static final byte NUM_FIELDS = 6;      // number of values expected from server
   public static final byte NUM_FIELDS_BETA = 3; // number of values expected from a 1.8b/1.3 server
   public static final int DEFAULT_TIMEOUT = 5;  // default TCP timeout in seconds

--- a/Java/me/dilley/MineStat.java
+++ b/Java/me/dilley/MineStat.java
@@ -27,6 +27,7 @@ package me.dilley;
 import com.google.gson.*;
 import java.io.*;
 import java.net.*;
+import java.nio.charset.StandardCharsets;
 
 public class MineStat
 {
@@ -242,7 +243,7 @@ public class MineStat
       if(rawServerData == null)
         return Retval.UNKNOWN;
 
-      serverData = new String(rawServerData, "UTF16").split("\u00A7"); // section symbol
+      serverData = new String(rawServerData, StandardCharsets.UTF_16).split("\u00A7"); // section symbol
       if(serverData.length >= NUM_FIELDS_BETA)
       {
         setVersion(">=1.8b/1.3"); // since server does not return version, set it
@@ -325,7 +326,7 @@ public class MineStat
       if(rawServerData == null)
         return Retval.UNKNOWN;
 
-      serverData = new String(rawServerData, "UTF16").split("\u0000"); // null
+      serverData = new String(rawServerData, StandardCharsets.UTF_16BE).split("\u0000"); // null
       if(serverData.length >= NUM_FIELDS)
       {
         // serverData[0] contains the section symbol and 1
@@ -403,12 +404,12 @@ public class MineStat
       dos.writeShort(0xFE01);
       dos.writeBytes("\u00FA");
       dos.writeBytes("\u0000\u000B");    // 11 (length of "MC|PingHost")
-      byte[] payload = "MC|PingHost".getBytes("UTF-16BE");
+      byte[] payload = "MC|PingHost".getBytes(StandardCharsets.UTF_16BE);
       dos.write(payload, 0, payload.length);
       dos.writeShort(7 + 2 * address.length());
       dos.writeBytes("\u004E");          // 78 (protocol version of 1.6.4)
       dos.writeShort(address.length());
-      payload = address.getBytes("UTF-16BE");
+      payload = address.getBytes(StandardCharsets.UTF_16BE);
       dos.write(payload, 0, payload.length);
       dos.writeInt(port);
       if(dis.readUnsignedByte() == 0xFF) // kick packet (255)
@@ -428,7 +429,7 @@ public class MineStat
       if(rawServerData == null)
         return Retval.UNKNOWN;
 
-      serverData = new String(rawServerData, "UTF16").split("\u0000"); // null
+      serverData = new String(rawServerData, StandardCharsets.UTF_16BE).split("\u0000"); // null
       if(serverData.length >= NUM_FIELDS)
       {
         // serverData[0] contains the section symbol and 1
@@ -575,6 +576,8 @@ public class MineStat
       int packetID = recvVarInt(dis);        // packet ID
       int jsonLength = recvVarInt(dis);      // JSON response size
       byte[] rawData = new byte[jsonLength]; // storage for JSON data
+
+      // TODO: Fully receive data
       dis.read(rawData);                     // fill byte array with JSON data
 
       // Close sockets
@@ -614,6 +617,7 @@ public class MineStat
       serverUp = false;
       return Retval.UNKNOWN;
     }
+
     return Retval.SUCCESS;
   }
 }

--- a/Java/me/dilley/MineStat.java
+++ b/Java/me/dilley/MineStat.java
@@ -277,7 +277,7 @@ public class MineStat
       {
         int dataLen = dis.readUnsignedShort();
         rawServerData = new byte[dataLen * 2];
-        dis.read(rawServerData, 0, dataLen * 2);
+        dis.readFully(rawServerData, 0, dataLen * 2);
         clientSocket.close();
       }
       else
@@ -359,8 +359,7 @@ public class MineStat
       {
         int dataLen = dis.readUnsignedShort();
         rawServerData = new byte[dataLen * 2];
-        // TODO: Implement full data retrieval (_recv_exact in Py)
-        dis.read(rawServerData, 0, dataLen * 2);
+        dis.readFully(rawServerData, 0, dataLen * 2);
         clientSocket.close();
       }
       else
@@ -462,8 +461,7 @@ public class MineStat
       {
         int dataLen = dis.readUnsignedShort();
         rawServerData = new byte[dataLen * 2];
-        // TODO: Fully receive data
-        dis.read(rawServerData, 0, dataLen * 2);
+        dis.readFully(rawServerData, 0, dataLen * 2);
         clientSocket.close();
       }
       else
@@ -623,8 +621,7 @@ public class MineStat
       int jsonLength = recvVarInt(dis);      // JSON response size
       byte[] rawData = new byte[jsonLength]; // storage for JSON data
 
-      // TODO: Fully receive data
-      dis.read(rawData);                     // fill byte array with JSON data
+      dis.readFully(rawData);                     // fill byte array with JSON data
 
       // Close sockets
       if (!clientSocket.isClosed()) {

--- a/Java/me/dilley/MineStat.java
+++ b/Java/me/dilley/MineStat.java
@@ -157,10 +157,10 @@ public class MineStat
         if(retval != Retval.SUCCESS && retval != Retval.CONNFAIL)
           retval = betaRequest(address, port, getTimeout());
         // SLP 1.6
-        if(retval != Retval.SUCCESS && retval != Retval.CONNFAIL)
+        if(retval != Retval.CONNFAIL)
           retval = extendedLegacyRequest(address, port, getTimeout());
         // SLP 1.7
-        if(retval != Retval.SUCCESS && retval != Retval.CONNFAIL)
+        if(retval != Retval.CONNFAIL)
           retval = jsonRequest(address, port, getTimeout());
     }
   }


### PR DESCRIPTION
## Proposed Changes
- Version bump for the Java version to 2.1.0
- Added field `strippedMotd` with appropriate getters/setters
- Added functions `stripMotdFormatting(String)` and `stripMotdFormatting(JsonObject)` for MOTD formatting stripping
- Fixed network problems:
  - Socket is now being closed in `jsonRequest`
  - Sending of SLP packet id is not fragmented anymore (`writeShort` instead of `writeBytes`)

This PR fixes issue FragLand/minestat#87.