### PR TITLE
Python: Initial Bedrock support

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -196,9 +196,14 @@ if ms.online:
   print('Message of the day without formatting: %s' % ms.stripped_motd)
   print('Latency: %sms' % ms.latency)
   print('Connected using protocol: %s' % ms.slp_protocol)
+  # Bedrock specific attribute:
+  if ms.slp_protocol is minestat.SlpProtocols.BEDROCK_RAKNET:
+    print('Game mode: %s' % ms.gamemode)
 else:
   print('Server is offline!')
 ```
+
+**See [the Python specific readme \(Python/README.md\)](../Python/README.md) for a full list of all supported attributes.**
 
 ### Ruby example
 

--- a/Python/README.md
+++ b/Python/README.md
@@ -20,6 +20,42 @@ if ms.online:
   print('Message of the day without formatting: %s' % ms.stripped_motd)
   print('Latency: %sms' % ms.latency)
   print('Connected using protocol: %s' % ms.slp_protocol)
+  # Bedrock specific attribute:
+  if ms.slp_protocol is minestat.SlpProtocols.BEDROCK_RAKNET:
+    print('Game mode: %s' % ms.gamemode)
 else:
   print('Server is offline!')
 ```
+
+#### Available attributes
+The following attributes are available on the `MineStat` object:
+
+- `online`: bool
+  - Whether the server is online and reachable with the specified protocol. True if online.
+- `address`: str
+  - Addresss (domain or IP-address) of the server to connect to.
+- `port`: int
+  - Port of the server to connect to.
+- `version`: str
+  - String describing the server Minecraft version. In vanilla servers the version number (e.g. 1.18.2),
+    may be modified by the server (e.g. by ViaVersion). On Bedrock servers includes the Edition (MCEE/MCPE)
+    and the server info.
+- `motd`: str
+  - The raw MOTD returned by the server. May include formatting codes (§) or JSON chat components.
+  - Examples (See https://github.com/FragLand/minestat/issues/84#issuecomment-895375890):
+    - With formatting codes: `§6~~§r §3§lM§7§lA§2§lG§9§lI§4§lC§r1.16 v3§6~~§r`
+    - JSON chat components: `{"extra": [{"color": "gold", "text": "~~"}, {"text": " "}, {"bold": true, "color": "dark_aqua", "text": "M"}, {"bold": true, "color": "gray", "text": "A"}, {"bold": true, "color": "dark_green", "text": "G"}, {"bold": true, "color": "blue", "text": "I"}, {"bold": true, "color": "dark_red", "text": "C"}, {"text": "1.16 v3"}, {"color": "gold", "text": "~~"}], "text": ""}`
+- `stripped_motd`: str
+  - The MOTD with all formatting removed ("human readable").
+  - Example (See https://github.com/FragLand/minestat/issues/84#issuecomment-895375890)
+    - Above MOTD example: `~~ MAGIC1.16 v3~~`
+- `current_players`: int
+  - Count of players currently online on the server.
+- `max_players`: int
+  - Count of maximum allowed players as reported by the server.
+- `latency`: int
+  - Time in milliseconds the server took to respond to the information request.
+- `slp_protocol`: minestat.SlpProtocol
+  - Protocol used to retrieve information from the server.
+- `gamemode`: str (***Bedrock specific***)
+  - Gamemode currently active on the server (Creative/Survival/Adventure). None if the server is not a Bedrock server.

--- a/Python/minestat/__init__.py
+++ b/Python/minestat/__init__.py
@@ -159,8 +159,8 @@ class MineStat:
     """socket timeout"""
     self.slp_protocol: Optional[SlpProtocols] = None
     """Server List Ping protocol"""
-    self.extra_data: Optional[dict] = None
-    """Extra data provided by a protocol not common to all request types (e.g. `json` vs `beta`)"""
+    self.gamemode: Optional[str] = None
+    """Bedrock specific: The current game mode (Creative/Survival/Adventure)"""
 
     # Future improvement: IPv4/IPv6, multiple addresses
     # If a host has multiple IP addresses or a IPv4 and a IPv6 address,
@@ -325,20 +325,20 @@ class MineStat:
     return self.__parse_bedrock_payload(response_id_string)
 
   def __parse_bedrock_payload(self, payload_str: str) -> ConnStatus:
-    motd_index = ["Edition", "MOTD line 1", "Protocol Version", "Version Name", "Player Count", "Max Player Count",
-                  "Server Unique ID", "MOTD line 2", "Game mode", "Game mode (numeric)", "Port (IPv4)", "Port (IPv6)"]
+    motd_index = ["edition", "motd_1", "protocol_version", "version", "current_players", "max_players",
+                  "server_uid", "motd_2", "gamemode", "gamemode_numeric", "port_ipv4", "port_ipv6"]
     payload = {e: f for e, f in zip(motd_index, payload_str.split(";"))}
 
     self.online = True
 
-    self.current_players = int(payload["Player Count"])
-    self.max_players = int(payload["Max Player Count"])
-    self.version = payload["Version Name"] + " " + payload["MOTD line 2"] + "(" + payload["Edition"] + ")"
+    self.current_players = int(payload["current_players"])
+    self.max_players = int(payload["max_players"])
+    self.version = payload["version"] + " " + payload["motd_2"] + "(" + payload["edition"] + ")"
 
-    self.motd = payload["MOTD line 1"]
+    self.motd = payload["motd_1"]
     self.stripped_motd = self.motd_strip_formatting(self.motd)
 
-    self.extra_data = payload
+    self.gamemode = payload["gamemode"]
 
     return ConnStatus.SUCCESS
 

--- a/Python/minestat/__init__.py
+++ b/Python/minestat/__init__.py
@@ -1,5 +1,5 @@
 # minestat.py - A Minecraft server status checker
-# Copyright (C) 2016-2021 Lloyd Dilley, Felix Ern (MindSolve)
+# Copyright (C) 2016-2022 Lloyd Dilley, Felix Ern (MindSolve)
 # http://www.dilley.me/
 #
 # This program is free software; you can redistribute it and/or modify

--- a/Python/minestat/__init__.py
+++ b/Python/minestat/__init__.py
@@ -135,7 +135,7 @@ Contains possible SLP (Server List Ping) protocols.
   """
 
 class MineStat:
-  VERSION = "2.2.0"             # MineStat version
+  VERSION = "2.3.0"             # MineStat version
   DEFAULT_TIMEOUT = 5           # default TCP timeout in seconds
 
   def __init__(self, address: str, port: int, timeout: int = DEFAULT_TIMEOUT, query_protocol: SlpProtocols = None) -> None:

--- a/Python/minestat/__init__.py
+++ b/Python/minestat/__init__.py
@@ -333,9 +333,9 @@ class MineStat:
 
     self.current_players = int(payload["Player Count"])
     self.max_players = int(payload["Max Player Count"])
-    self.version = payload["Version Name"]
+    self.version = payload["Version Name"] + " " + payload["MOTD line 2"] + "(" + payload["Edition"] + ")"
 
-    self.motd = payload["MOTD line 1"] + "\n" + payload["MOTD line 2"]
+    self.motd = payload["MOTD line 1"]
     self.stripped_motd = self.motd_strip_formatting(self.motd)
 
     self.extra_data = payload

--- a/Python/setup.cfg
+++ b/Python/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = minestat 
-version = 2.2.0
+version = 2.3.0
 author = Lloyd Dilley
 author_email = minecraft@frag.land
 description = A Minecraft server status checker


### PR DESCRIPTION
## Proposed Changes
- Adds initial support for Bedrock servers (unconnected ping packets), see #45
- Adds type annotations, where necessary or useful
- Bumps Python package version to 2.3.0
- Adds full documentation of all attributes

@ldilley: Could you have a look at the below questions/problems? What do you think? And should this be done before merging this PR? Thanks!

## Known problems/improvement potential
- `bedrock_raknet_query` currently behaves "TCP-like", assuming no dropped packets.
  - A reliability should be implemented (resending of packets)
- Many places still speak of SLP protocol, even though they mean/contain all possible protocols.
  - Should be renamed to something general, such as simply `Protocol`
  - Serverquery could be implemented in a similar way, as just another request protocol.
- ~The `extra_data` object is only used in the bedrock protocol~
  - ~Should be used by all protocols exposing additional data, that is not covered by the common properties.~

## Other open points
- [x] Whether to include the MotD line 2 in the `motd` property (as second line, like in the other protocols), or include it in the version property (like in the ruby edition)
- [x] Whether to include the `extra_data` property at all, or add properties that are only used for single protocols.
  - Decided to not use the `extra_data` property, instead to add protocol specific attributes