### PR TITLE
fix request when request_type is passed

### DIFF
--- a/Ruby/lib/minestat.rb
+++ b/Ruby/lib/minestat.rb
@@ -123,15 +123,15 @@ class MineStat
           retval = beta_request()
         end
         # SLP 1.6
-        unless retval == Retval::CONNFAIL
+        unless retval == Retval::SUCCESS || retval == Retval::CONNFAIL
           retval = extended_legacy_request()
         end
         # SLP 1.7
-        unless retval == Retval::CONNFAIL
+        unless retval == Retval::SUCCESS || retval == Retval::CONNFAIL
           retval = json_request()
         end
         # Bedrock/Pocket Edition
-        unless retval == Retval::CONNFAIL
+        unless retval == Retval::SUCCESS || retval == Retval::CONNFAIL
           retval = bedrock_request()
         end
     end


### PR DESCRIPTION
When no request_type was passed, the code tried to request on all versions even if there is a success, and it erase this success

Proposed Changes : test if requests have success