### PR TITLE
Reset formatting after formatted_motd 

### DIFF
--- a/PowerShell/MineStat.psd1
+++ b/PowerShell/MineStat.psd1
@@ -40,6 +40,7 @@
 ## 2.0.3
 - Fix bug parsing "§" on powershell version 5
 - Add support for spliting "Address:Port" in address input
+- Add formating/color reset in formatted_motd
 
 ## 2.0.2
 - Fix release notes.

--- a/PowerShell/MineStat.psd1
+++ b/PowerShell/MineStat.psd1
@@ -39,21 +39,21 @@
       ReleaseNotes = @'
 ## 2.0.3
 - Fix bug parsing "§" on powershell version 5
-- Add support for spliting "Address:Port" in address input
-- Add formating/color reset in formatted_motd
+- Add support for splitting "Address:Port" in address input
+- Add formatting/color reset in formatted_motd
 
 ## 2.0.2
-- Fix release notes.
-- Add link to license.
-- Add more tags.
+- Fix release notes
+- Add link to license
+- Add more tags
 
 ## 2.0.1
-- Convert script to module.
+- Convert script to module
 
 ## 2.0.0
-- Add Bedrock, JSON, legacy, and extended legacy support.
-- Add support for MotD stripping.
-- Add $formatted_motd to display MotD with escaped unicode character in console.
+- Add Bedrock, JSON, legacy, and extended legacy support
+- Add support for MotD stripping
+- Add $formatted_motd to display MotD with escaped unicode character in console
 
 ## 1.0.0
 - Initial release

--- a/PowerShell/MineStat.psm1
+++ b/PowerShell/MineStat.psm1
@@ -244,7 +244,7 @@ function MineStat {
               $formatted_motd += $format
             }
           }
-          return $formatted_motd
+          return $formatted_motd + $formats.reset
         }
         else {
           foreach ($entry in $rawmotd) {
@@ -267,7 +267,7 @@ function MineStat {
           if ($formatted_motd -match [char]0x00A7) {
             $formatted_motd = format_motd($formatted_motd)
           }
-          return $formatted_motd
+          return $formatted_motd + $formats.reset
         }
       }
       $this.stripped_motd = strip_motd($rawmotd)


### PR DESCRIPTION
## Proposed Changes
- Added formatting reset after formatted_motd

Before change:
![before](https://user-images.githubusercontent.com/21109286/179422894-7117824d-9836-46a0-a8d8-ce374c309076.JPG)
After change:
![color reset](https://user-images.githubusercontent.com/21109286/179422948-bc61519d-dcf6-40c0-bd38-cbd20e096b21.JPG)
