### PR TITLE
Java Bedrock support

### DIFF
--- a/Java/Example.java
+++ b/Java/Example.java
@@ -9,6 +9,8 @@ class Example
     if(ms.isServerUp())
     {
       System.out.println("Server is online running version " + ms.getVersion() + " with " + ms.getCurrentPlayers() + " out of " + ms.getMaximumPlayers() + " players.");
+      if(ms.getRequestType() == "Bedrock/Pocket Edition")
+        System.out.println("Game mode: " + ms.getGameMode());
       System.out.println("Message of the day: " + ms.getMotd());
       System.out.println("Message of the day without formatting: " + ms.getStrippedMotd());
       System.out.println("Latency: " + ms.getLatency() + "ms");

--- a/Java/Example.java
+++ b/Java/Example.java
@@ -4,7 +4,7 @@ class Example
 {
   public static void main(String[] args)
   {
-    MineStat ms = new MineStat("fun.frag.land");
+    MineStat ms = new MineStat("fun.frag.land", 19132);
     //MineStat ms = new MineStat("fun.frag.land", 19132, 5, MineStat.Request.BEDROCK);
     System.out.println("Minecraft server status of " + ms.getAddress() + " on port " + ms.getPort() + ":");
     if(ms.isServerUp())

--- a/Java/Example.java
+++ b/Java/Example.java
@@ -9,7 +9,7 @@ class Example
     if(ms.isServerUp())
     {
       System.out.println("Server is online running version " + ms.getVersion() + " with " + ms.getCurrentPlayers() + " out of " + ms.getMaximumPlayers() + " players.");
-      if(ms.getRequestType() == "Bedrock/Pocket Edition")
+      if(ms.getRequestType().equals("Bedrock/Pocket Edition"))
         System.out.println("Game mode: " + ms.getGameMode());
       System.out.println("Message of the day: " + ms.getMotd());
       System.out.println("Message of the day without formatting: " + ms.getStrippedMotd());

--- a/Java/Example.java
+++ b/Java/Example.java
@@ -4,8 +4,7 @@ class Example
 {
   public static void main(String[] args)
   {
-    MineStat ms = new MineStat("fun.frag.land", 19132);
-    //MineStat ms = new MineStat("fun.frag.land", 19132, 5, MineStat.Request.BEDROCK);
+    MineStat ms = new MineStat("minecraft.frag.land", 25565);
     System.out.println("Minecraft server status of " + ms.getAddress() + " on port " + ms.getPort() + ":");
     if(ms.isServerUp())
     {

--- a/Java/Example.java
+++ b/Java/Example.java
@@ -4,7 +4,7 @@ class Example
 {
   public static void main(String[] args)
   {
-    MineStat ms = new MineStat("fun.frag.land", 19132, MineStat.Request.BEDROCK);
+    MineStat ms = new MineStat("fun.frag.land");
     //MineStat ms = new MineStat("fun.frag.land", 19132, 5, MineStat.Request.BEDROCK);
     System.out.println("Minecraft server status of " + ms.getAddress() + " on port " + ms.getPort() + ":");
     if(ms.isServerUp())

--- a/Java/Example.java
+++ b/Java/Example.java
@@ -4,7 +4,8 @@ class Example
 {
   public static void main(String[] args)
   {
-    MineStat ms = new MineStat("fun.frag.land", 19132, 5, MineStat.Request.BEDROCK);
+    MineStat ms = new MineStat("fun.frag.land", 19132, MineStat.Request.BEDROCK);
+    //MineStat ms = new MineStat("fun.frag.land", 19132, 5, MineStat.Request.BEDROCK);
     System.out.println("Minecraft server status of " + ms.getAddress() + " on port " + ms.getPort() + ":");
     if(ms.isServerUp())
     {

--- a/Java/Example.java
+++ b/Java/Example.java
@@ -4,7 +4,7 @@ class Example
 {
   public static void main(String[] args)
   {
-    MineStat ms = new MineStat("minecraft.frag.land", 25565);
+    MineStat ms = new MineStat("fun.frag.land", 19132, 5, MineStat.Request.BEDROCK);
     System.out.println("Minecraft server status of " + ms.getAddress() + " on port " + ms.getPort() + ":");
     if(ms.isServerUp())
     {

--- a/Java/me/dilley/MineStat.java
+++ b/Java/me/dilley/MineStat.java
@@ -39,6 +39,7 @@ public class MineStat
   public static final int DEFAULT_TIMEOUT = 5;          // default TCP/UDP timeout in seconds
   public static final int DEFAULT_SLP_PORT = 25565;     // default TCP port
   public static final int DEFAULT_BEDROCK_PORT = 19132; // default UDP port for Bedrock/Pocket Edition servers
+  public static final int SERVER_ID_STRING_OFFSET = 35; // server ID string offset for Bedrock/Pocket Edition servers
 
   public enum Retval
   {
@@ -774,7 +775,7 @@ public class MineStat
 
       /* Parse data */
       int serverIdLength = rawServerData[34]; // server ID string length
-      String serverId = new String(Arrays.copyOfRange(rawServerData, 35, 35 + serverIdLength), StandardCharsets.UTF_8);
+      String serverId = new String(Arrays.copyOfRange(rawServerData, SERVER_ID_STRING_OFFSET, SERVER_ID_STRING_OFFSET + serverIdLength), StandardCharsets.UTF_8);
       String[] splitData = serverId.split(";");
       serverUp = true;
       setProtocol(Integer.parseInt(splitData[2]));

--- a/Java/me/dilley/MineStat.java
+++ b/Java/me/dilley/MineStat.java
@@ -148,6 +148,11 @@ public class MineStat
     this(address, port, timeout, Request.NONE);
   }
 
+  public MineStat(String address, int port, Request requestType)
+  {
+    this(address, port, DEFAULT_TIMEOUT, requestType);
+  }
+
   public MineStat(String address, int port, int timeout, Request requestType)
   {
     setAddress(address);

--- a/Java/me/dilley/MineStat.java
+++ b/Java/me/dilley/MineStat.java
@@ -183,8 +183,18 @@ public class MineStat
          * since it may be due to an issue during the handshake.
          * Note: Newer server versions may still respond to older SLP requests.
          */
+        Retval retval = Retval.UNKNOWN;
+        boolean bedrockAttempted = false;
+        // Try Bedrock request first if port matches the default Bedrock port
+        if(port == DEFAULT_BEDROCK_PORT)
+        {
+          bedrockAttempted = true;
+          retval = bedrockRequest(address, port, getTimeout());
+          if(retval == Retval.SUCCESS)
+            break;
+        }
         // SLP 1.4/1.5
-        Retval retval = legacyRequest(address, port, getTimeout());
+          retval = legacyRequest(address, port, getTimeout());
         // SLP 1.8b/1.3
         if(retval != Retval.SUCCESS && retval != Retval.CONNFAIL)
           retval = betaRequest(address, port, getTimeout());
@@ -195,7 +205,7 @@ public class MineStat
         if(retval != Retval.CONNFAIL)
           retval = jsonRequest(address, port, getTimeout());
         // Bedrock/Pocket Edition
-        if(retval != Retval.CONNFAIL)
+        if(retval != Retval.CONNFAIL && !bedrockAttempted)
         {
           if(!isPortDefined)
             setPort(DEFAULT_BEDROCK_PORT);

--- a/Java/me/dilley/MineStat.java
+++ b/Java/me/dilley/MineStat.java
@@ -728,14 +728,14 @@ public class MineStat
   {
     return new byte[]
     {
-      (byte)((data >> 56) & 0xff),
-      (byte)((data >> 48) & 0xff),
-      (byte)((data >> 40) & 0xff),
-      (byte)((data >> 32) & 0xff),
-      (byte)((data >> 24) & 0xff),
-      (byte)((data >> 16) & 0xff),
-      (byte)((data >> 8)  & 0xff),
-      (byte)((data >> 0)  & 0xff),
+      (byte)((data >> 56) & 0xFF),
+      (byte)((data >> 48) & 0xFF),
+      (byte)((data >> 40) & 0xFF),
+      (byte)((data >> 32) & 0xFF),
+      (byte)((data >> 24) & 0xFF),
+      (byte)((data >> 16) & 0xFF),
+      (byte)((data >> 8)  & 0xFF),
+      (byte)((data >> 0)  & 0xFF),
     };
   }
 
@@ -807,7 +807,7 @@ public class MineStat
         clientSocket.close();
 
       /* Parse data */
-      int serverIdLength = rawServerData[34]; // server ID string length
+      short serverIdLength = (short)(((rawServerData[33] & 0xFF) << 8) | (rawServerData[34] & 0xFF)); // server ID string length
       String serverId = new String(Arrays.copyOfRange(rawServerData, SERVER_ID_STRING_OFFSET, SERVER_ID_STRING_OFFSET + serverIdLength), StandardCharsets.UTF_8);
       String[] splitData = serverId.split(";");
       serverUp = true;

--- a/Java/me/dilley/MineStat.java
+++ b/Java/me/dilley/MineStat.java
@@ -302,6 +302,7 @@ public class MineStat
       {
         setVersion(">=1.8b/1.3"); // since server does not return version, set it
         setMotd(serverData[0]);
+        setStrippedMotd(stripMotdFormatting(serverData[0]));
         setCurrentPlayers(Integer.parseInt(serverData[1]));
         setMaximumPlayers(Integer.parseInt(serverData[2]));
         serverUp = true;
@@ -386,6 +387,7 @@ public class MineStat
         // serverData[1] contains the protocol version (51 for example)
         setVersion(serverData[2]);
         setMotd(serverData[3]);
+        setStrippedMotd(stripMotdFormatting(serverData[3]));
         setCurrentPlayers(Integer.parseInt(serverData[4]));
         setMaximumPlayers(Integer.parseInt(serverData[5]));
         serverUp = true;
@@ -488,6 +490,7 @@ public class MineStat
         // serverData[1] contains the protocol version (always 127 for >=1.7.x)
         setVersion(serverData[2]);
         setMotd(serverData[3]);
+        setStrippedMotd(stripMotdFormatting(serverData[3]));
         setCurrentPlayers(Integer.parseInt(serverData[4]));
         setMaximumPlayers(Integer.parseInt(serverData[5]));
         serverUp = true;

--- a/Java/me/dilley/MineStat.java
+++ b/Java/me/dilley/MineStat.java
@@ -135,25 +135,25 @@ public class MineStat
 
   public MineStat(String address)
   {
-    this(address, DEFAULT_SLP_PORT, DEFAULT_TIMEOUT, Request.NONE);
+    this(address, DEFAULT_SLP_PORT, DEFAULT_TIMEOUT, Request.NONE, false);
   }
 
   public MineStat(String address, int port)
   {
-    this(address, port, DEFAULT_TIMEOUT, Request.NONE);
+    this(address, port, DEFAULT_TIMEOUT, Request.NONE, true);
   }
 
   public MineStat(String address, int port, int timeout)
   {
-    this(address, port, timeout, Request.NONE);
+    this(address, port, timeout, Request.NONE, true);
   }
 
   public MineStat(String address, int port, Request requestType)
   {
-    this(address, port, DEFAULT_TIMEOUT, requestType);
+    this(address, port, DEFAULT_TIMEOUT, requestType, true);
   }
 
-  public MineStat(String address, int port, int timeout, Request requestType)
+  public MineStat(String address, int port, int timeout, Request requestType, boolean isPortDefined)
   {
     setAddress(address);
     setPort(port);
@@ -196,7 +196,11 @@ public class MineStat
           retval = jsonRequest(address, port, getTimeout());
         // Bedrock/Pocket Edition
         if(retval != Retval.CONNFAIL)
+        {
+          if(!isPortDefined)
+            setPort(DEFAULT_BEDROCK_PORT);
           retval = bedrockRequest(address, port, getTimeout());
+        }
     }
   }
 

--- a/Java/me/dilley/MineStat.java
+++ b/Java/me/dilley/MineStat.java
@@ -772,7 +772,7 @@ public class MineStat
   {
     try
     {
-      byte[] rawServerData = new byte[512];
+      byte[] rawServerData = new byte[1280];
       byte[] request = null;
       DatagramPacket requestPacket = null;
       DatagramPacket responsePacket = null;

--- a/Java/me/dilley/MineStat.java
+++ b/Java/me/dilley/MineStat.java
@@ -1,6 +1,6 @@
 /*
  * MineStat.java - A Minecraft server status checker
- * Copyright (C) 2014-2021 Lloyd Dilley
+ * Copyright (C) 2014-2022 Lloyd Dilley
  * http://www.dilley.me/
  *
  * This program is free software; you can redistribute it and/or modify

--- a/Java/me/dilley/MineStat.java
+++ b/Java/me/dilley/MineStat.java
@@ -84,6 +84,12 @@ public class MineStat
   private boolean serverUp;
 
   /**
+   * Game mode
+   * @since 3.0.0
+   */
+  private String gameMode;
+
+  /**
    * Message of the day from the server
    */
   private String motd;
@@ -201,6 +207,10 @@ public class MineStat
 
   public void setTimeout(int timeout) { this.timeout = timeout; }
 
+  public String getGameMode() { return gameMode; }
+
+  public void setGameMode(String gameMode) { this.gameMode = gameMode; }
+
   public String getMotd() { return motd; }
 
   public void setMotd(String motd) { this.motd = motd; }
@@ -313,6 +323,7 @@ public class MineStat
       if(serverData.length >= NUM_FIELDS_BETA)
       {
         setVersion(">=1.8b/1.3"); // since server does not return version, set it
+        setGameMode("Unspecified");
         setMotd(serverData[0]);
         setStrippedMotd(stripMotdFormatting(serverData[0]));
         setCurrentPlayers(Integer.parseInt(serverData[1]));
@@ -404,6 +415,7 @@ public class MineStat
         setCurrentPlayers(Integer.parseInt(serverData[4]));
         setMaximumPlayers(Integer.parseInt(serverData[5]));
         serverUp = true;
+        setGameMode("Unspecified");
         setRequestType("SLP 1.4/1.5 (legacy)");
       }
       else
@@ -507,6 +519,7 @@ public class MineStat
         setCurrentPlayers(Integer.parseInt(serverData[4]));
         setMaximumPlayers(Integer.parseInt(serverData[5]));
         serverUp = true;
+        setGameMode("Unspecified");
         setRequestType("SLP 1.6 (extended legacy)");
       }
       else
@@ -660,6 +673,7 @@ public class MineStat
       setCurrentPlayers(jobj.get("players").getAsJsonObject().get("online").getAsInt());
       setMaximumPlayers(jobj.get("players").getAsJsonObject().get("max").getAsInt());
       serverUp = true;
+      setGameMode("Unspecified");
       setRequestType("SLP 1.7 (JSON)");
       if(!isDataValid())
         return Retval.UNKNOWN;
@@ -784,6 +798,7 @@ public class MineStat
       setMotd(splitData[1]);
       setStrippedMotd(stripMotdFormatting(splitData[1]));
       setVersion(splitData[3] + " " + splitData[7] + " (" + splitData[0] + ")");
+      setGameMode(splitData[8]);
       setRequestType("Bedrock/Pocket Edition");
     }
     catch(ConnectException ce)

--- a/Java/me/dilley/MineStat.java
+++ b/Java/me/dilley/MineStat.java
@@ -115,7 +115,14 @@ public class MineStat
   private long latency;
 
   /**
-   * SLP protocol version
+   * Protocol level
+   * Note: Multiple Minecraft versions can share the same protocol level
+   * @since 3.0.0
+   */
+  private int protocol;
+
+  /**
+   * Protocol version
    */
   private String requestType;
 
@@ -252,6 +259,10 @@ public class MineStat
 
   public void setLatency(long latency) { this.latency = latency; }
 
+  public int getProtocol() { return protocol; }
+
+  public void setProtocol(int protocol) { this.protocol = protocol; }
+
   public boolean isServerUp() { return serverUp; }
 
   public String getRequestType() { return requestType; }
@@ -305,6 +316,7 @@ public class MineStat
         setStrippedMotd(stripMotdFormatting(serverData[0]));
         setCurrentPlayers(Integer.parseInt(serverData[1]));
         setMaximumPlayers(Integer.parseInt(serverData[2]));
+        setProtocol(0);           // set to zero (unknown) since 1.8b/1.3 server does not provide protocol level
         serverUp = true;
         setRequestType("SLP 1.8b/1.3 (beta)");
       }
@@ -384,7 +396,7 @@ public class MineStat
       if(serverData.length >= NUM_FIELDS)
       {
         // serverData[0] contains the section symbol and 1
-        // serverData[1] contains the protocol version (51 for example)
+        setProtocol(Integer.parseInt(serverData[1])); // 49 for 1.4.5 for example
         setVersion(serverData[2]);
         setMotd(serverData[3]);
         setStrippedMotd(stripMotdFormatting(serverData[3]));
@@ -487,7 +499,7 @@ public class MineStat
       if(serverData.length >= NUM_FIELDS)
       {
         // serverData[0] contains the section symbol and 1
-        // serverData[1] contains the protocol version (always 127 for >=1.7.x)
+        setProtocol(Integer.parseInt(serverData[1])); // 78 for 1.6.4 for example
         setVersion(serverData[2]);
         setMotd(serverData[3]);
         setStrippedMotd(stripMotdFormatting(serverData[3]));
@@ -640,6 +652,7 @@ public class MineStat
 
       // Populate object from JSON data
       JsonObject jobj = new Gson().fromJson(new String(rawData), JsonObject.class);
+      setProtocol(jobj.get("version").getAsJsonObject().get("protocol").getAsInt());
       setMotd(jobj.get("description").toString());
       setStrippedMotd(stripMotdFormatting(jobj.get("description").getAsJsonObject()));
       setVersion(jobj.get("version").getAsJsonObject().get("name").getAsString());
@@ -764,6 +777,7 @@ public class MineStat
       String serverId = new String(Arrays.copyOfRange(rawServerData, 35, 35 + serverIdLength), StandardCharsets.UTF_8);
       String[] splitData = serverId.split(";");
       serverUp = true;
+      setProtocol(Integer.parseInt(splitData[2]));
       setCurrentPlayers(Integer.parseInt(splitData[4]));
       setMaximumPlayers(Integer.parseInt(splitData[5]));
       setMotd(splitData[1]);

--- a/Java/pom.xml
+++ b/Java/pom.xml
@@ -4,7 +4,7 @@
   <name>MineStat</name>
   <groupId>io.github.fragland</groupId>
   <artifactId>MineStat</artifactId>
-  <version>2.0.0</version>
+  <version>3.0.0</version>
   <packaging>jar</packaging>
   <description>MineStat is a Minecraft server status checker.</description>
   <url>https://github.com/fragland/minestat</url>


### PR DESCRIPTION
## Proposed Changes
- Add Bedrock support for Java (related to #45).
- Increment version to `3.0.0`.
- Supply stripped MotDs for all request types.
- Add protocol level.
- Add game mode.
- Attempt Bedrock query and update port automatically if no port and no request type are specified.
- If no request type is specified and the specified port matches the default Bedrock UDP port, try the Bedrock query first.
