### PR TITLE
Update Java version and dependency versions

### DIFF
--- a/Java/build.gradle
+++ b/Java/build.gradle
@@ -6,7 +6,7 @@ sourceSets
   {
     dependencies
     {
-      implementation 'com.google.code.gson:gson:2.8.6'
+      implementation 'com.google.code.gson:gson:2.9.1'
     }
     repositories
     {

--- a/Java/me/dilley/MineStat.java
+++ b/Java/me/dilley/MineStat.java
@@ -33,7 +33,7 @@ import java.util.Date;
 
 public class MineStat
 {
-  public static final String VERSION = "3.0.0";         // MineStat version
+  public static final String VERSION = "3.0.1";         // MineStat version
   public static final byte NUM_FIELDS = 6;              // number of values expected from server
   public static final byte NUM_FIELDS_BETA = 3;         // number of values expected from a 1.8b/1.3 server
   public static final int DEFAULT_TIMEOUT = 5;          // default TCP/UDP timeout in seconds

--- a/Java/pom.xml
+++ b/Java/pom.xml
@@ -115,6 +115,20 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-gpg-plugin</artifactId>
+        <version>1.5</version>
+        <executions>
+          <execution>
+            <id>sign-artifacts</id>
+            <phase>verify</phase>
+            <goals>
+              <goal>sign</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
   <profiles>

--- a/Java/pom.xml
+++ b/Java/pom.xml
@@ -39,7 +39,7 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.8.1</version>
+      <version>4.13.2</version>
       <!--<scope>test</scope>-->
     </dependency>
 

--- a/Java/pom.xml
+++ b/Java/pom.xml
@@ -4,7 +4,7 @@
   <name>MineStat</name>
   <groupId>io.github.fragland</groupId>
   <artifactId>MineStat</artifactId>
-  <version>3.0.0</version>
+  <version>3.0.1</version>
   <packaging>jar</packaging>
   <description>MineStat is a Minecraft server status checker.</description>
   <url>https://github.com/fragland/minestat</url>

--- a/Java/pom.xml
+++ b/Java/pom.xml
@@ -46,7 +46,7 @@
     <dependency>
       <groupId>com.google.code.gson</groupId>
       <artifactId>gson</artifactId>
-      <version>2.8.6</version>
+      <version>2.9.1</version>
     </dependency>
   </dependencies>
 


### PR DESCRIPTION
## Proposed Changes
- Add Maven GPG signing plugin to `pom.xml` since Maven Central repository requires JAR file signing during deployment.
- Update Gson library version from 2.8.6 to 2.9.1 for Gradle and Maven (related to #117).
- Update JUnit version from 4.8.1 to 4.13.2 (related to #117).
- Increment version from 3.0.0 to 3.0.1 (related to #117).
