### PR TITLE
Java and Ruby bug fixes, favicon and connection status support

### DIFF
--- a/Java/Example.java
+++ b/Java/Example.java
@@ -4,7 +4,7 @@ class Example
 {
   public static void main(String[] args)
   {
-    MineStat ms = new MineStat("minecraft.frag.land", 25565);
+    MineStat ms = new MineStat("minecraft.frag.land");
     System.out.println("Minecraft server status of " + ms.getAddress() + " on port " + ms.getPort() + ":");
     if(ms.isServerUp())
     {

--- a/Java/me/dilley/MineStat.java
+++ b/Java/me/dilley/MineStat.java
@@ -146,6 +146,12 @@ public class MineStat
    */
   private String requestType;
 
+  /**
+   * Connection status
+   * @since 3.0.2
+   */
+  private String connectionStatus;
+
   public MineStat(String address)
   {
     this(address, DEFAULT_SLP_PORT, DEFAULT_TIMEOUT, Request.NONE, false);
@@ -171,22 +177,23 @@ public class MineStat
     setAddress(address);
     setPort(port);
     setTimeout(timeout);
+    Retval retval = Retval.UNKNOWN;
     switch(requestType)
     {
       case BETA:
-        betaRequest(address, port, getTimeout());
+        retval = betaRequest(address, port, getTimeout());
         break;
       case LEGACY:
-        legacyRequest(address, port, getTimeout());
+        retval = legacyRequest(address, port, getTimeout());
         break;
       case EXTENDED:
-        extendedLegacyRequest(address, port, getTimeout());
+        retval = extendedLegacyRequest(address, port, getTimeout());
         break;
       case JSON:
-        jsonRequest(address, port, getTimeout());
+        retval = jsonRequest(address, port, getTimeout());
         break;
       case BEDROCK:
-        bedrockRequest(address, port, getTimeout());
+        retval = bedrockRequest(address, port, getTimeout());
         break;
       default:
         /*
@@ -196,7 +203,6 @@ public class MineStat
          * since it may be due to an issue during the handshake.
          * Note: Newer server versions may still respond to older SLP requests.
          */
-        Retval retval = Retval.UNKNOWN;
         boolean bedrockAttempted = false;
         // Try Bedrock request first if port matches the default Bedrock port
         if(port == DEFAULT_BEDROCK_PORT)
@@ -225,6 +231,7 @@ public class MineStat
           retval = bedrockRequest(address, port, getTimeout());
         }
     }
+    setConnectionStatus(retval);
   }
 
   public String getAddress() { return address; }
@@ -319,6 +326,20 @@ public class MineStat
   public String getRequestType() { return requestType; }
 
   public void setRequestType(String requestType) { this.requestType = requestType; }
+
+  public String getConnectionStatus() { return connectionStatus; }
+
+  public void setConnectionStatus(Retval connectionStatusCode)
+  {
+    if(connectionStatusCode == Retval.SUCCESS)
+      connectionStatus = "Success";
+    else if(connectionStatusCode == Retval.CONNFAIL)
+      connectionStatus = "Fail";
+    else if(connectionStatusCode == Retval.TIMEOUT)
+      connectionStatus = "Timeout";
+    else
+      connectionStatus = "Unknown";
+  }
 
   /*
    * 1.8b/1.3

--- a/Java/me/dilley/MineStat.java
+++ b/Java/me/dilley/MineStat.java
@@ -34,7 +34,7 @@ import java.util.Date;
 
 public class MineStat
 {
-  public static final String VERSION = "3.0.1";         // MineStat version
+  public static final String VERSION = "3.0.2";         // MineStat version
   public static final byte NUM_FIELDS = 6;              // number of values expected from server
   public static final byte NUM_FIELDS_BETA = 3;         // number of values expected from a 1.8b/1.3 server
   public static final int DEFAULT_TIMEOUT = 5;          // default TCP/UDP timeout in seconds

--- a/Java/me/dilley/MineStat.java
+++ b/Java/me/dilley/MineStat.java
@@ -226,7 +226,7 @@ public class MineStat
         // Bedrock/Pocket Edition
         if(!isServerUp())
         {
-          if(retval != Retval.SUCCESS || retval != Retval.CONNFAIL && !bedrockAttempted)
+          if(retval != Retval.SUCCESS && !bedrockAttempted)
           {
             if(!isPortDefined)
               setPort(DEFAULT_BEDROCK_PORT);

--- a/Java/me/dilley/MineStat.java
+++ b/Java/me/dilley/MineStat.java
@@ -34,7 +34,7 @@ import java.util.Date;
 
 public class MineStat
 {
-  public static final String VERSION = "3.0.3";         // MineStat version
+  public static final String VERSION = "3.0.4";         // MineStat version
   public static final byte NUM_FIELDS = 6;              // number of values expected from server
   public static final byte NUM_FIELDS_BETA = 3;         // number of values expected from a 1.8b/1.3 server
   public static final int DEFAULT_TIMEOUT = 5;          // default TCP/UDP timeout in seconds

--- a/Java/me/dilley/MineStat.java
+++ b/Java/me/dilley/MineStat.java
@@ -34,7 +34,7 @@ import java.util.Date;
 
 public class MineStat
 {
-  public static final String VERSION = "3.0.2";         // MineStat version
+  public static final String VERSION = "3.0.3";         // MineStat version
   public static final byte NUM_FIELDS = 6;              // number of values expected from server
   public static final byte NUM_FIELDS_BETA = 3;         // number of values expected from a 1.8b/1.3 server
   public static final int DEFAULT_TIMEOUT = 5;          // default TCP/UDP timeout in seconds

--- a/Java/me/dilley/MineStat.java
+++ b/Java/me/dilley/MineStat.java
@@ -224,14 +224,20 @@ public class MineStat
         if(retval != Retval.CONNFAIL)
           retval = jsonRequest(address, port, getTimeout());
         // Bedrock/Pocket Edition
-        if(retval != Retval.SUCCESS || retval != Retval.CONNFAIL && !bedrockAttempted)
+        if(!isServerUp())
         {
-          if(!isPortDefined)
-            setPort(DEFAULT_BEDROCK_PORT);
-          retval = bedrockRequest(address, port, getTimeout());
+          if(retval != Retval.SUCCESS || retval != Retval.CONNFAIL && !bedrockAttempted)
+          {
+            if(!isPortDefined)
+              setPort(DEFAULT_BEDROCK_PORT);
+            retval = bedrockRequest(address, port, getTimeout());
+          }
         }
     }
-    setConnectionStatus(retval);
+    if(isServerUp())
+      setConnectionStatus(Retval.SUCCESS);
+    else
+      setConnectionStatus(retval);
   }
 
   public String getAddress() { return address; }
@@ -415,7 +421,6 @@ public class MineStat
     }
     catch(Exception e)
     {
-      serverUp = false;
       return Retval.UNKNOWN;
     }
     return Retval.SUCCESS;
@@ -501,7 +506,6 @@ public class MineStat
     }
     catch(Exception e)
     {
-      serverUp = false;
       return Retval.UNKNOWN;
     }
     return Retval.SUCCESS;
@@ -605,7 +609,6 @@ public class MineStat
     }
     catch(Exception e)
     {
-      serverUp = false;
       return Retval.UNKNOWN;
     }
     return Retval.SUCCESS;
@@ -739,9 +742,17 @@ public class MineStat
       setVersion(jobj.get("version").getAsJsonObject().get("name").getAsString());
       setCurrentPlayers(jobj.get("players").getAsJsonObject().get("online").getAsInt());
       setMaximumPlayers(jobj.get("players").getAsJsonObject().get("max").getAsInt());
-      setFaviconB64(jobj.get("favicon").getAsString().split("base64,")[1]);
-      if(getFaviconB64() != null && !getFaviconB64().isEmpty())
-        setFavicon(new String(Base64.getDecoder().decode(getFaviconB64())));
+      try
+      {
+        setFaviconB64(jobj.get("favicon").getAsString().split("base64,")[1]);
+        if(getFaviconB64() != null && !getFaviconB64().isEmpty())
+          setFavicon(new String(Base64.getDecoder().decode(getFaviconB64())));
+      }
+      catch(Exception e)
+      {
+        setFaviconB64(null);
+        setFavicon("");
+      }
       serverUp = true;
       setGameMode("Unspecified");
       setRequestType("SLP 1.7 (JSON)");
@@ -766,7 +777,6 @@ public class MineStat
     }
     catch(Exception e)
     {
-      serverUp = false;
       return Retval.UNKNOWN;
     }
     return Retval.SUCCESS;
@@ -889,7 +899,6 @@ public class MineStat
     }
     catch(Exception e)
     {
-      serverUp = false;
       return Retval.UNKNOWN;
     }
     return Retval.SUCCESS;

--- a/Java/me/dilley/MineStat.java
+++ b/Java/me/dilley/MineStat.java
@@ -397,7 +397,6 @@ public class MineStat
         setMaximumPlayers(Integer.parseInt(serverData[2]));
         setProtocol(0);           // set to zero (unknown) since 1.8b/1.3 server does not provide protocol level
         serverUp = true;
-        setRequestType("SLP 1.8b/1.3 (beta)");
       }
       else
         return Retval.UNKNOWN;
@@ -423,6 +422,7 @@ public class MineStat
     {
       return Retval.UNKNOWN;
     }
+    setRequestType("SLP 1.8b/1.3 (beta)");
     return Retval.SUCCESS;
   }
 
@@ -482,7 +482,6 @@ public class MineStat
         setMaximumPlayers(Integer.parseInt(serverData[5]));
         serverUp = true;
         setGameMode("Unspecified");
-        setRequestType("SLP 1.4/1.5 (legacy)");
       }
       else
         return Retval.UNKNOWN;
@@ -508,6 +507,7 @@ public class MineStat
     {
       return Retval.UNKNOWN;
     }
+    setRequestType("SLP 1.4/1.5 (legacy)");
     return Retval.SUCCESS;
   }
 
@@ -585,7 +585,6 @@ public class MineStat
         setMaximumPlayers(Integer.parseInt(serverData[5]));
         serverUp = true;
         setGameMode("Unspecified");
-        setRequestType("SLP 1.6 (extended legacy)");
       }
       else
         return Retval.UNKNOWN;
@@ -611,6 +610,7 @@ public class MineStat
     {
       return Retval.UNKNOWN;
     }
+    setRequestType("SLP 1.6 (extended legacy)");
     return Retval.SUCCESS;
   }
 
@@ -755,7 +755,6 @@ public class MineStat
       }
       serverUp = true;
       setGameMode("Unspecified");
-      setRequestType("SLP 1.7 (JSON)");
       if(!isDataValid())
         return Retval.UNKNOWN;
     }
@@ -779,6 +778,7 @@ public class MineStat
     {
       return Retval.UNKNOWN;
     }
+    setRequestType("SLP 1.7 (JSON)");
     return Retval.SUCCESS;
   }
 
@@ -879,7 +879,6 @@ public class MineStat
       setStrippedMotd(stripMotdFormatting(splitData[1]));
       setVersion(splitData[3] + " " + splitData[7] + " (" + splitData[0] + ")");
       setGameMode(splitData[8]);
-      setRequestType("Bedrock/Pocket Edition");
     }
     catch(ConnectException ce)
     {
@@ -901,6 +900,7 @@ public class MineStat
     {
       return Retval.UNKNOWN;
     }
+    setRequestType("Bedrock/Pocket Edition");
     return Retval.SUCCESS;
   }
 }

--- a/Java/me/dilley/MineStat.java
+++ b/Java/me/dilley/MineStat.java
@@ -218,7 +218,7 @@ public class MineStat
         if(retval != Retval.CONNFAIL)
           retval = jsonRequest(address, port, getTimeout());
         // Bedrock/Pocket Edition
-        if(retval != Retval.CONNFAIL && !bedrockAttempted)
+        if(retval != Retval.SUCCESS || retval != Retval.CONNFAIL && !bedrockAttempted)
         {
           if(!isPortDefined)
             setPort(DEFAULT_BEDROCK_PORT);

--- a/Java/me/dilley/MineStat.java
+++ b/Java/me/dilley/MineStat.java
@@ -707,7 +707,14 @@ public class MineStat
       JsonObject jobj = new Gson().fromJson(new String(rawData), JsonObject.class);
       setProtocol(jobj.get("version").getAsJsonObject().get("protocol").getAsInt());
       setMotd(jobj.get("description").toString());
-      setStrippedMotd(stripMotdFormatting(jobj.get("description").getAsJsonObject()));
+      try
+      {
+        setStrippedMotd(stripMotdFormatting(jobj.get("description").getAsJsonObject()));
+      }
+      catch(Exception e)
+      {
+        setStrippedMotd(stripMotdFormatting(jobj.get("description").toString()));
+      }
       setVersion(jobj.get("version").getAsJsonObject().get("name").getAsString());
       setCurrentPlayers(jobj.get("players").getAsJsonObject().get("online").getAsInt());
       setMaximumPlayers(jobj.get("players").getAsJsonObject().get("max").getAsInt());

--- a/Java/pom.xml
+++ b/Java/pom.xml
@@ -4,7 +4,7 @@
   <name>MineStat</name>
   <groupId>io.github.fragland</groupId>
   <artifactId>MineStat</artifactId>
-  <version>3.0.1</version>
+  <version>3.0.2</version>
   <packaging>jar</packaging>
   <description>MineStat is a Minecraft server status checker.</description>
   <url>https://github.com/fragland/minestat</url>

--- a/Java/pom.xml
+++ b/Java/pom.xml
@@ -4,7 +4,7 @@
   <name>MineStat</name>
   <groupId>io.github.fragland</groupId>
   <artifactId>MineStat</artifactId>
-  <version>3.0.2</version>
+  <version>3.0.3</version>
   <packaging>jar</packaging>
   <description>MineStat is a Minecraft server status checker.</description>
   <url>https://github.com/fragland/minestat</url>

--- a/Java/pom.xml
+++ b/Java/pom.xml
@@ -4,7 +4,7 @@
   <name>MineStat</name>
   <groupId>io.github.fragland</groupId>
   <artifactId>MineStat</artifactId>
-  <version>3.0.3</version>
+  <version>3.0.4</version>
   <packaging>jar</packaging>
   <description>MineStat is a Minecraft server status checker.</description>
   <url>https://github.com/fragland/minestat</url>

--- a/Ruby/lib/minestat.rb
+++ b/Ruby/lib/minestat.rb
@@ -97,7 +97,8 @@ class MineStat
     @latency              # ping time to server in milliseconds
     @timeout = timeout    # TCP/UDP timeout
     @server               # server socket
-    @request_type         # Protocol version
+    @request_type         # protocol version
+    @connection_status    # status of connection ("Success", "Fail", "Timeout", or "Unknown")
     @try_all = false      # try all protocols?
 
     @try_all = true if request_type == Request::NONE
@@ -138,7 +139,16 @@ class MineStat
           retval = bedrock_request()
         end
     end
+    set_connection_status(retval)
     @online = false unless retval == Retval::SUCCESS
+  end
+
+  # Sets connection status
+  def set_connection_status(retval)
+    @connection_status = "Success" if retval == Retval::SUCCESS
+    @connection_status = "Fail" if retval == Retval::CONNFAIL
+    @connection_status = "Timeout" if retval == Retval::TIMEOUT
+    @connection_status = "Unknown" if retval == Retval::UNKNOWN
   end
 
   # Strips message of the day formatting characters
@@ -588,6 +598,9 @@ class MineStat
 
   # Returns the protocol version
   attr_reader :request_type
+
+  # Returns the connection status
+  attr_reader :connection_status
 
   # Returns whether or not all ping protocols should be attempted
   attr_reader :try_all

--- a/Ruby/lib/minestat.rb
+++ b/Ruby/lib/minestat.rb
@@ -135,7 +135,7 @@ class MineStat
           retval = json_request()
         end
         # Bedrock/Pocket Edition
-        unless @online || retval == Retval::SUCCESS || retval == Retval::CONNFAIL
+        unless @online || retval == Retval::SUCCESS
           retval = bedrock_request()
         end
     end
@@ -537,6 +537,7 @@ class MineStat
     retval = nil
     begin
       Timeout::timeout(@timeout) do
+        @request_type = "Bedrock/Pocket Edition"
         retval = connect()
         return retval unless retval == Retval::SUCCESS
         # Perform handshake and acquire data
@@ -555,7 +556,6 @@ class MineStat
       return Retval::UNKNOWN
     end
     if retval == Retval::SUCCESS
-      @request_type = "Bedrock/Pocket Edition"
       set_connection_status(retval)
     end
     return retval

--- a/Ruby/lib/minestat.rb
+++ b/Ruby/lib/minestat.rb
@@ -25,7 +25,7 @@ require 'timeout'
 # Provides a ruby interface for polling Minecraft server status.
 class MineStat
   # MineStat version
-  VERSION = "2.2.1"
+  VERSION = "2.2.2"
   # Number of values expected from server
   NUM_FIELDS = 6
   # Number of values expected from a 1.8b/1.3 server

--- a/Ruby/lib/minestat.rb
+++ b/Ruby/lib/minestat.rb
@@ -25,7 +25,7 @@ require 'timeout'
 # Provides a ruby interface for polling Minecraft server status.
 class MineStat
   # MineStat version
-  VERSION = "2.2.3"
+  VERSION = "2.2.4"
   # Number of values expected from server
   NUM_FIELDS = 6
   # Number of values expected from a 1.8b/1.3 server

--- a/Ruby/lib/minestat.rb
+++ b/Ruby/lib/minestat.rb
@@ -16,6 +16,7 @@
 # with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
+require 'base64'
 require 'json'
 require 'socket'
 require 'timeout'
@@ -91,6 +92,8 @@ class MineStat
     @max_players          # maximum player capacity
     @protocol             # protocol level
     @json_data            # JSON data for 1.7 queries
+    @favicon_b64          # base64-encoded favicon possibly contained in JSON 1.7 responses
+    @favicon              # decoded favicon data
     @latency              # ping time to server in milliseconds
     @timeout = timeout    # TCP/UDP timeout
     @server               # server socket
@@ -428,6 +431,11 @@ class MineStat
         strip_motd
         @current_players = json_data['players']['online'].to_i
         @max_players = json_data['players']['max'].to_i
+        @favicon_b64 = json_data['favicon']
+        if !@favicon_b64.nil? && !@favicon_b64.empty?
+          @favicon_b64 = favicon_b64.split("base64,")[1]
+          @favicon = Base64.decode64(favicon_b64)
+        end
         if !@version.empty? && !@motd.empty? && !@current_players.nil? && !@max_players.nil?
           @online = true
         else
@@ -568,6 +576,12 @@ class MineStat
   # Returns the complete JSON response data for queries to Minecraft
   # servers with a version greater than or equal to 1.7
   attr_reader :json_data
+
+  # Returns the base64-encoded favicon from JSON 1.7 queries
+  attr_reader :favicon_b64
+
+  # Returns the decoded favicon from JSON 1.7 queries
+  attr_reader :favicon
 
   # Returns the ping time to the server in ms
   attr_reader :latency

--- a/Ruby/lib/minestat.rb
+++ b/Ruby/lib/minestat.rb
@@ -134,7 +134,7 @@ class MineStat
           retval = json_request()
         end
         # Bedrock/Pocket Edition
-        unless retval == Retval::CONNFAIL
+        unless retval == Retval::SUCCESS || retval == Retval::CONNFAIL
           retval = bedrock_request()
         end
     end

--- a/Ruby/lib/minestat.rb
+++ b/Ruby/lib/minestat.rb
@@ -135,12 +135,11 @@ class MineStat
           retval = json_request()
         end
         # Bedrock/Pocket Edition
-        unless retval == Retval::SUCCESS || retval == Retval::CONNFAIL
+        unless @online || retval == Retval::SUCCESS || retval == Retval::CONNFAIL
           retval = bedrock_request()
         end
     end
-    set_connection_status(retval)
-    @online = false unless retval == Retval::SUCCESS
+    set_connection_status(retval) unless @online
   end
 
   # Sets connection status
@@ -286,7 +285,6 @@ class MineStat
         retval = connect()
         return retval unless retval == Retval::SUCCESS
         # Perform handshake and acquire data
-        @request_type = "SLP 1.8b/1.3 (beta)"
         @server.write("\xFE")
         retval = parse_data("\u00A7", true) # section symbol
       end
@@ -295,6 +293,10 @@ class MineStat
     rescue => exception
       $stderr.puts exception
       return Retval::UNKNOWN
+    end
+    if retval == Retval::SUCCESS
+      @request_type = "SLP 1.8b/1.3 (beta)"
+      set_connection_status(retval)
     end
     return retval
   end
@@ -325,7 +327,6 @@ class MineStat
         retval = connect()
         return retval unless retval == Retval::SUCCESS
         # Perform handshake and acquire data
-        @request_type = "SLP 1.4/1.5 (legacy)"
         @server.write("\xFE\x01")
         retval = parse_data("\x00") # null
       end
@@ -334,6 +335,10 @@ class MineStat
     rescue => exception
       $stderr.puts exception
       return Retval::UNKNOWN
+    end
+    if retval == Retval::SUCCESS
+      @request_type = "SLP 1.4/1.5 (legacy)"
+      set_connection_status(retval)
     end
     return retval
   end
@@ -372,7 +377,6 @@ class MineStat
         retval = connect()
         return retval unless retval == Retval::SUCCESS
         # Perform handshake and acquire data
-        @request_type = "SLP 1.6 (extended legacy)"
         @server.write("\xFE\x01\xFA")
         @server.write("\x00\x0B") # 11 (length of "MC|PingHost")
         @server.write('MC|PingHost'.encode('UTF-16BE').force_encoding('ASCII-8BIT'))
@@ -388,6 +392,10 @@ class MineStat
     rescue => exception
       $stderr.puts exception
       return Retval::UNKNOWN
+    end
+    if retval == Retval::SUCCESS
+      @request_type = "SLP 1.6 (extended legacy)"
+      set_connection_status(retval)
     end
     return retval
   end
@@ -415,7 +423,6 @@ class MineStat
         retval = connect()
         return retval unless retval == Retval::SUCCESS
         # Perform handshake
-        @request_type = "SLP 1.7 (JSON)"
         payload = "\x00\x00"
         payload += [@address.length].pack('c') << @address
         payload += [@port].pack('n')
@@ -459,6 +466,10 @@ class MineStat
     rescue => exception
       $stderr.puts exception
       return Retval::UNKNOWN
+    end
+    if retval == Retval::SUCCESS
+      @request_type = "SLP 1.7 (JSON)"
+      set_connection_status(retval)
     end
     return retval
   end
@@ -526,7 +537,6 @@ class MineStat
     retval = nil
     begin
       Timeout::timeout(@timeout) do
-        @request_type = "Bedrock/Pocket Edition"
         retval = connect()
         return retval unless retval == Retval::SUCCESS
         # Perform handshake and acquire data
@@ -543,6 +553,10 @@ class MineStat
     rescue => exception
       $stderr.puts exception
       return Retval::UNKNOWN
+    end
+    if retval == Retval::SUCCESS
+      @request_type = "Bedrock/Pocket Edition"
+      set_connection_status(retval)
     end
     return retval
   end

--- a/Ruby/lib/minestat.rb
+++ b/Ruby/lib/minestat.rb
@@ -25,7 +25,7 @@ require 'timeout'
 # Provides a ruby interface for polling Minecraft server status.
 class MineStat
   # MineStat version
-  VERSION = "2.2.2"
+  VERSION = "2.2.3"
   # Number of values expected from server
   NUM_FIELDS = 6
   # Number of values expected from a 1.8b/1.3 server

--- a/Ruby/minestat.gemspec
+++ b/Ruby/minestat.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = "minestat"
-  s.version = "2.2.2"
+  s.version = "2.2.3"
   s.authors = ["Lloyd Dilley"]
   s.email = ["minecraft@frag.land"]
   s.summary = "Minecraft server status checker"

--- a/Ruby/minestat.gemspec
+++ b/Ruby/minestat.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = "minestat"
-  s.version = "2.2.1"
+  s.version = "2.2.2"
   s.authors = ["Lloyd Dilley"]
   s.email = ["minecraft@frag.land"]
   s.summary = "Minecraft server status checker"

--- a/Ruby/minestat.gemspec
+++ b/Ruby/minestat.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = "minestat"
-  s.version = "2.2.3"
+  s.version = "2.2.4"
   s.authors = ["Lloyd Dilley"]
   s.email = ["minecraft@frag.land"]
   s.summary = "Minecraft server status checker"


### PR DESCRIPTION
## Proposed Changes
- Add favicon support (related to #120).
- Expose connection status (related to #119).
- Increment Java version from `3.0.1` to `3.0.2`.
- Increment Ruby version from `2.2.1` to `2.2.2`.
- Fix bug in Java version during MotD strip where JSON query `description` field was a string instead of a JSON object.
- Fix bug where connection details were overwritten if a Bedrock request was attempted after a JSON request was successful.