### PR TITLE
Dual Target the C# Package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,8 @@ venv/
 # Ignore all compiled c# files
 *.exe
 *.dll
+
+#Visual Studio Files
+.vs/
+**/bin/Debug/
+**/bin/Release/

--- a/CSharp/MineStat/MineStat.csproj
+++ b/CSharp/MineStat/MineStat.csproj
@@ -18,10 +18,9 @@
     <Version>3.0.1.0</Version>
   </PropertyGroup>
   <PropertyGroup>
-    <TargetFramework>net46</TargetFramework>
+    <TargetFrameworks>net46;netstandard20</TargetFrameworks>
     <Deterministic>true</Deterministic>
-    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
-    <AppendRuntimeIdentifierToOutputPath>false</AppendRuntimeIdentifierToOutputPath>
+    <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -42,14 +41,4 @@
     <WarningLevel>4</WarningLevel>
     <DocumentationFile>bin\Release\MineStat.xml</DocumentationFile>
   </PropertyGroup>
-  <ItemGroup>
-    <Reference Include="System"/>
-    <Reference Include="System.Core"/>
-    <Reference Include="System.Runtime.Serialization"/>
-    <Reference Include="System.Data.DataSetExtensions"/>
-    <Reference Include="Microsoft.CSharp"/>
-    <Reference Include="System.Data"/>
-    <Reference Include="System.Xml"/>
-    <Reference Include="System.Xml.Linq"/>
-  </ItemGroup>
 </Project>


### PR DESCRIPTION
## Proposed Changes
-Convert TargetFramework to TargetFrameworks to allow Net Core and Net 5+ To work with the library
-Allow it to add the dotnet Version to the path so both versions build properly.
-Remove the references group as its not used by standard and it should not be needed by 4.6
-Tweak the gitignore to ignore the visual studio cache files
