### PR TITLE
Favicon for C#

### DIFF
--- a/CSharp/MineStat/MineStat.cs
+++ b/CSharp/MineStat/MineStat.cs
@@ -24,6 +24,7 @@ using System.Net.Sockets;
 using System.Text;
 using System.Text.RegularExpressions;
 using System.Diagnostics;
+using System.Drawing;
 using System.IO;
 using System.Linq;
 using System.Runtime.Serialization.Json;
@@ -133,6 +134,11 @@ namespace MineStatLib
     /// Bedrock specific: The current gamemode (Creative/Survival/Adventure)
     /// </summary>
     public string Gamemode { get; set; }
+    /// <summary>
+    /// Favicon for the Minecraft server when returned by the server (in base64 format)
+    /// </summary>
+    public string Favicon { get; set; }
+
     /// <inheritdoc cref="MineStat"/>
     /// <example>
     /// <code>
@@ -446,6 +452,7 @@ namespace MineStatLib
 
         // Extract version
         Version = root.XPathSelectElement("//version/name")?.Value;
+        Favicon = root.XPathSelectElement("//favicon")?.Value;
 
         // the MOTD
         var descriptionElement = root.XPathSelectElement("//description");

--- a/CSharp/MineStat/MineStat.cs
+++ b/CSharp/MineStat/MineStat.cs
@@ -24,7 +24,6 @@ using System.Net.Sockets;
 using System.Text;
 using System.Text.RegularExpressions;
 using System.Diagnostics;
-using System.Drawing;
 using System.IO;
 using System.Linq;
 using System.Runtime.Serialization.Json;

--- a/CSharp/MineStat/MineStat.cs
+++ b/CSharp/MineStat/MineStat.cs
@@ -452,6 +452,8 @@ namespace MineStatLib
 
         // Extract version
         Version = root.XPathSelectElement("//version/name")?.Value;
+
+        // Favicon
         Favicon = root.XPathSelectElement("//favicon")?.Value;
 
         // the MOTD


### PR DESCRIPTION
## Proposed Changes
-C#'s favicon for #120

Correct me if I'm wrong, but looking at the other versions that are done already and the server responses, its only the JSON version that actually has the favicon.  

Also left it just as a string, since to get to a bitmap in 4.6 is fine, but netstandard2.0, has no native support but has a Nuget that would lock it to windows only... and as someone is intending to be use this on a Ubuntu server with net6, that would cause issues.
