### PR TITLE
Update C# version and copyright year [skip ci]

### DIFF
--- a/CSharp/MineStat/MineStat.cs
+++ b/CSharp/MineStat/MineStat.cs
@@ -1,6 +1,6 @@
 /*
  * MineStat.cs - A Minecraft server status checker
- * Copyright (C) 2014-2022 Lloyd Dilley, 2021-2022 Felix Ern (MindSolve), 2022 Ajoro
+ * Copyright (C) 2014-2023 Lloyd Dilley, 2021-2023 Felix Ern (MindSolve), 2022-2023 Ajoro
  * http://www.dilley.me/
  *
  * This program is free software; you can redistribute it and/or modify
@@ -43,7 +43,7 @@ namespace MineStatLib
     /// <summary>
     /// The MineStat library version.
     /// </summary>
-    public const string MineStatVersion = "3.0.2";
+    public const string MineStatVersion = "3.1.0";
     /// <summary>
     /// Default TCP timeout in seconds.
     /// </summary>

--- a/CSharp/MineStat/MineStat.csproj
+++ b/CSharp/MineStat/MineStat.csproj
@@ -6,16 +6,16 @@
     <Description>A Minecraft server status checker</Description>
     <Company>Frag Land</Company>
     <Product>MineStat</Product>
-    <Copyright>Copyright © 2014-2022 Lloyd Dilley, 2021-2022 Felix Ern (MindSolve), 2022 Ajoro</Copyright>
+    <Copyright>Copyright © 2014-2023 Lloyd Dilley, 2021-2023 Felix Ern (MindSolve), 2022-2023 Ajoro</Copyright>
     <Authors>Lloyd Dilley, Felix Ern, Ajoro</Authors>
 
     <!--The following GUID is for the ID of the typelib if this project is exposed to COM-->
     <ProjectGuid>{11EDD760-FC1E-4BC0-8ED4-8F6D8FF97779}</ProjectGuid>
 
     <!-- Version information for an assembly consists of the following four values: Major.Minor.Build.Revision -->
-    <AssemblyVersion>3.0.2.0</AssemblyVersion>
-    <FileVersion>3.0.2.0</FileVersion>
-    <Version>3.0.2.0</Version>
+    <AssemblyVersion>3.1.0.0</AssemblyVersion>
+    <FileVersion>3.1.0.0</FileVersion>
+    <Version>3.1.0.0</Version>
   </PropertyGroup>
   <PropertyGroup>
     <TargetFrameworks>net46;netstandard20</TargetFrameworks>

--- a/CSharp/MineStat/Properties/AssemblyInfo.cs
+++ b/CSharp/MineStat/Properties/AssemblyInfo.cs
@@ -9,7 +9,7 @@ using System.Runtime.InteropServices;
 // [assembly: AssemblyConfiguration("")]
 // [assembly: AssemblyCompany("Frag Land")]
 // [assembly: AssemblyProduct("MineStat")]
-// [assembly: AssemblyCopyright("Copyright © 2014-2022 Lloyd Dilley, 2021-2022 Felix Ern (MindSolve), 2022 Ajoro")]
+// [assembly: AssemblyCopyright("Copyright © 2014-2023 Lloyd Dilley, 2021-2023 Felix Ern (MindSolve), 2022-2023 Ajoro")]
 // [assembly: AssemblyTrademark("")]
 // [assembly: AssemblyCulture("")]
 
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-// [assembly: AssemblyVersion("3.0.2.0")]
-// [assembly: AssemblyFileVersion("3.0.2.0")]
+// [assembly: AssemblyVersion("3.1.0.0")]
+// [assembly: AssemblyFileVersion("3.1.0.0")]


### PR DESCRIPTION
## Proposed Changes
- Update copyright year.
- Update version to `3.1.0` to fix package properties when publishing to nuget.org.
