### PR TITLE
Fix missing Bedrock fields (C#, PS)

### DIFF
--- a/CSharp/MineStat/MineStat.cs
+++ b/CSharp/MineStat/MineStat.cs
@@ -361,10 +361,16 @@ namespace MineStatLib
       ServerUp = true;
       CurrentPlayersInt = Convert.ToInt32(dic["current_players"]);
       MaximumPlayersInt = Convert.ToInt32(dic["max_players"]);
-      Version = dic["version"] + " " + dic["motd_2"] + " (" + dic["edition"] + ")";
+      // motd_2 not returned on older bedrock versions
+      if (dic.ContainsKey("motd_2"))
+        Version = dic["version"] + " " + dic["motd_2"] + " (" + dic["edition"] + ")";
+      else
+        Version = dic["version"] + " (" + dic["edition"] + ")";
       Motd = dic["motd_1"];
       Stripped_Motd = strip_motd_formatting(Motd);
-      Gamemode = dic["gamemode"];
+      // gamemode can be empty on older bedrock versions
+      if (dic.ContainsKey("gamemode"))
+        Gamemode = dic["gamemode"];
       return ConnStatus.Success;
     }
     /// <summary>

--- a/CSharp/MineStat/MineStat.cs
+++ b/CSharp/MineStat/MineStat.cs
@@ -43,7 +43,7 @@ namespace MineStatLib
     /// <summary>
     /// The MineStat library version.
     /// </summary>
-    public const string MineStatVersion = "3.1.0";
+    public const string MineStatVersion = "3.1.1";
     /// <summary>
     /// Default TCP timeout in seconds.
     /// </summary>

--- a/CSharp/MineStat/MineStat.csproj
+++ b/CSharp/MineStat/MineStat.csproj
@@ -13,9 +13,9 @@
     <ProjectGuid>{11EDD760-FC1E-4BC0-8ED4-8F6D8FF97779}</ProjectGuid>
 
     <!-- Version information for an assembly consists of the following four values: Major.Minor.Build.Revision -->
-    <AssemblyVersion>3.1.0.0</AssemblyVersion>
-    <FileVersion>3.1.0.0</FileVersion>
-    <Version>3.1.0.0</Version>
+    <AssemblyVersion>3.1.1.0</AssemblyVersion>
+    <FileVersion>3.1.1.0</FileVersion>
+    <Version>3.1.1.0</Version>
   </PropertyGroup>
   <PropertyGroup>
     <TargetFrameworks>net46;netstandard20</TargetFrameworks>

--- a/CSharp/MineStat/Properties/AssemblyInfo.cs
+++ b/CSharp/MineStat/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-// [assembly: AssemblyVersion("3.1.0.0")]
-// [assembly: AssemblyFileVersion("3.1.0.0")]
+// [assembly: AssemblyVersion("3.1.1.0")]
+// [assembly: AssemblyFileVersion("3.1.1.0")]

--- a/PowerShell/MineStat/MineStat.psd1
+++ b/PowerShell/MineStat/MineStat.psd1
@@ -1,7 +1,7 @@
 ###
 # ==++==
 #
-# Copyright (C) 2020-2022 Ajoro and MineStat contributors.
+# Copyright (C) 2020-2023 Ajoro and MineStat contributors.
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -21,9 +21,9 @@
   GUID = '9adc7f28-e495-424d-83ef-8e48b08b5909'
   Author = "Ajoro and MineStat contributors"
   CompanyName = "Frag Land"
-  Copyright = "(C) 2020-2022 Ajoro and MineStat contributors"
+  Copyright = "(C) 2020-2023 Ajoro and MineStat contributors"
   HelpInfoUri = "https://github.com/FragLand/minestat/tree/master/PowerShell"
-  ModuleVersion = "2.0.4"
+  ModuleVersion = "2.0.5"
   PowerShellVersion = "5.0"
   RootModule = "MineStat.psm1"
   Description = "MineStat is a Minecraft server connection status checker."
@@ -37,6 +37,11 @@
       ProjectUri = "https://github.com/FragLand/minestat"
       LicenseUri = "https://www.gnu.org/licenses/gpl-3.0.txt"
       ReleaseNotes = @'
+## 2.0.5
+- Renamed connstatus to connection_status
+- Made verbose command display better 
+- Add -version to display current script version
+
 ## 2.0.4
 - Exposed connstatus
 

--- a/PowerShell/MineStat/MineStat.psd1
+++ b/PowerShell/MineStat/MineStat.psd1
@@ -39,8 +39,9 @@
       ReleaseNotes = @'
 ## 2.0.5
 - Renamed connstatus to connection_status
-- Made verbose command display better 
-- Add -version to display current script version
+- Hide empty motd_2 (bedrock_raknet)
+- Add scriptversion to verbose output
+- Fix verbose output not displaying currentstatus
 
 ## 2.0.4
 - Exposed connstatus

--- a/PowerShell/MineStat/MineStat.psm1
+++ b/PowerShell/MineStat/MineStat.psm1
@@ -44,9 +44,7 @@ function MineStat {
       })]
     $Protocol = 15,
     # The time in seconds, after which a connection is timed out. 
-    [int]$Timeout = 5,
-    # Display current script version
-    [switch]$version
+    [int]$Timeout = 5
   )
 
   enum ConnStatus {
@@ -71,10 +69,8 @@ function MineStat {
     Unknown = 0
   }
 
-  if ($version){
-    $ModuleInfos = Import-PowerShellDataFile -Path "$PsScriptRoot\MineStat.psd1"
-    Write-Host "MineStat version: $($ModuleInfos.ModuleVersion.ToString())"
-  }
+  $ModuleInfos = Import-PowerShellDataFile -Path "$PsScriptRoot\MineStat.psd1"
+  Write-Verbose "MineStat version: $($ModuleInfos.ModuleVersion.ToString())"
 
   try {
     # Return array if address input is array
@@ -394,7 +390,7 @@ function MineStat {
       $this.online = $true;
       $this.current_players = $payload_obj.current_players
       $this.max_players = $payload_obj.max_players
-      $this.version = "$($payload_obj.version) $($payload_obj.motd_2) ($($payload_obj.edition))"
+      $this.version = @($payload_obj.version, $payload_obj.motd_2, "($($payload_obj.edition))") -ne $null -join " "
       $this.motd = $payload_obj.motd_1
       $this.generateMotds($this.motd)
       $this.Gamemode = $payload_obj.gamemode

--- a/PowerShell/MineStat/MineStat.psm1
+++ b/PowerShell/MineStat/MineStat.psm1
@@ -1,6 +1,6 @@
 ###
 # MineStat.psm1
-# Copyright (C) 2020-2022 Ajoro and MineStat contributors.
+# Copyright (C) 2020-2023 Ajoro and MineStat contributors.
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -44,7 +44,9 @@ function MineStat {
       })]
     $Protocol = 15,
     # The time in seconds, after which a connection is timed out. 
-    [int]$Timeout = 5
+    [int]$Timeout = 5,
+    # Display current script version
+    [switch]$version
   )
 
   enum ConnStatus {
@@ -67,6 +69,11 @@ function MineStat {
     Legacy = 2
     Beta = 1
     Unknown = 0
+  }
+
+  if ($version){
+    $ModuleInfos = Import-PowerShellDataFile -Path "$PsScriptRoot\MineStat.psd1"
+    Write-Host "MineStat version: $($ModuleInfos.ModuleVersion.ToString())"
   }
 
   try {
@@ -840,7 +847,7 @@ function MineStat {
       return [ConnStatus]::Success
     }
 
-    [byte[]] NetStreamReadExact([System.Net.Sockets.NetworkStream]$stream, [int]$size) {
+    hidden [byte[]] NetStreamReadExact([System.Net.Sockets.NetworkStream]$stream, [int]$size) {
       $totalReadBytes = 0
       $resultBuffer = New-Object System.Collections.Generic.List[byte]
 

--- a/PowerShell/README.md
+++ b/PowerShell/README.md
@@ -26,7 +26,7 @@ if ($ms.Online) {
 ### Commandline Example
 
 ```powershell
-PS C:\> MineStat -Address "localhost","mc.hypixel.net" -Port 25565 -Protocol Beta,Extendedlegacy,Json -Timeout 2 -verbose
+PS C:\> MineStat -Address "localhost","mc.hypixel.net:25565" -Port 25568 -Protocol Beta,Extendedlegacy,Json -Timeout 2 -verbose
 VERBOSE: Beta, ExtendedLegacy, Json
 VERBOSE: Beta - Success
 VERBOSE: ExtendedLegacy - Success
@@ -37,7 +37,7 @@ VERBOSE: ExtendedLegacy - Unknown
 VERBOSE: Json - Success
 
 address         : localhost
-port            : 25565
+port            : 25568
 online          : True
 current_players : 3
 max_players     : 20
@@ -74,21 +74,25 @@ slp_protocol    : BedrockRaknet
 - `Address`: str[] / str
   - Address (domain or IP-address) of the server to connect to. 
   - Can take array input and also take `address:port` as input.
+  - Default: localhost
 - `Port`: uint
   - Port of the server to connect to.
+  - Default: 25565
 - `Protocol`: int / str / array
-  - SlpProtocol to use. Dosn't use bedrock by default.
+  - SlpProtocol to use.
+  - Dosn't use BedrockRaknet by default.
 - `Timeout`: int
   - Time in seconds before timeout (for each SlpProtocol)
+  - Default: 5
 
 #### Available attributes
 
-- `online`: bool
-  - Whether the server is online and reachable with the specified protocol. True if online.
 - `address`: str
   - Addresss (domain or IP-address) of the server to connect to.
 - `port`: int
   - Port of the server to connect to.
+- `online`: bool
+  - Whether the server is online and reachable with the specified protocol. True if online.
 - `version`: str
   - String describing the server Minecraft version. In vanilla servers the version number (e.g. 1.18.2),
     may be modified by the server (e.g. by ViaVersion). On Bedrock servers includes the Edition (MCEE/MCPE)
@@ -101,7 +105,7 @@ slp_protocol    : BedrockRaknet
   - Count of maximum allowed players as reported by the server.
 - `latency`: int
   - Time in milliseconds the server took to respond to the information request.
-- `slp_protocol`: SlpProtocol
+- `slp_protocol`: minestat.SlpProtocol
   - Protocol used to retrieve information from the server.
 
 #### Extra attributes
@@ -110,8 +114,10 @@ slp_protocol    : BedrockRaknet
   - Gamemode currently active on the server (Creative/Survival/Adventure). None if the server is not a Bedrock server.
 - `playerlist`: str[] (**_Json specific_**)
   - List of current playernames. \*Ignored by some servers.
-- `favicion`: str (**_Json specific_**)
+- `favicon`: str (**_Json specific_**)
   - Server favicon in base64.
+- `connection_status`: minestat.ConnStatus
+  - Status of connection ("Success", "Connfail", "InvalidResponse", "Timeout", or "Unknown").
 - `motd`: str
   - The raw MOTD returned by the server. May include formatting codes (§) or JSON chat components.
   - Examples (See https://github.com/FragLand/minestat/issues/84#issuecomment-895375890):
@@ -121,3 +127,5 @@ slp_protocol    : BedrockRaknet
   - The MOTD with all formatting removed ("human readable").
   - Example (See https://github.com/FragLand/minestat/issues/84#issuecomment-895375890)
     - Above MOTD example: `~~ MAGIC1.16 v3~~`
+- `timeout`: int
+  - Time in seconds before timeout (for each SlpProtocol) from input

--- a/PowerShell/README.md
+++ b/PowerShell/README.md
@@ -27,6 +27,7 @@ if ($ms.Online) {
 
 ```powershell
 PS C:\> MineStat -Address "localhost","mc.hypixel.net:25565" -Port 25568 -Protocol Beta,Extendedlegacy,Json -Timeout 2 -verbose
+VERBOSE: MineStat version: 2.0.5
 VERBOSE: Beta, ExtendedLegacy, Json
 VERBOSE: Beta - Success
 VERBOSE: ExtendedLegacy - Success


### PR DESCRIPTION
## Proposed Changes
- C#: Fix fields not existing on older bedrock servers (related: #137)
- PS: Hide fields not existing on older bedrock servers (related: #137)
- PS: Rename connstatus to connection_status
- PS: Rename fail to connfail
- PS: Update readme and copyright
- PS: Fix verbose output bug and add script version to verbose output
