### PR TITLE
add support for bedrock servers

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -22,7 +22,7 @@ If you are planning to host MineStat on a shared webhost, make sure that the pro
 |**1.4/1.5 (legacy)**|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|
 |**1.6 (extended legacy)**|:heavy_check_mark:|:x:|:heavy_check_mark:|:x:|:x:|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|
 |**>=1.7 (JSON)**|:heavy_check_mark:|:x:|:heavy_check_mark:|:x:|:x:|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|
-|**Bedrock/PE/RakNet**|:heavy_check_mark:|:x:|:heavy_check_mark:|:x:|:x:|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|
+|**Bedrock/PE/RakNet**|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|:x:|:x:|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|
 
 ## Examples :memo:
 

--- a/Go/minestat/minestat.go
+++ b/Go/minestat/minestat.go
@@ -30,7 +30,7 @@ import (
 	"golang.org/x/text/encoding/unicode"
 )
 
-const VERSION string = "2.0.0"     // MineStat version
+const VERSION string = "2.1.0"     // MineStat version
 const NUM_FIELDS uint8 = 6         // number of values expected from server
 const NUM_FIELDS_BETA uint8 = 3    // number of values expected from a 1.8b/1.3 server
 const DEFAULT_TCP_PORT = 25565     // default TCP port

--- a/Go/minestat/minestat.go
+++ b/Go/minestat/minestat.go
@@ -20,11 +20,15 @@
 
 package minestat
 
-import "net"
-import "strconv"
-import "strings"
-import "time"
-import "golang.org/x/text/encoding/unicode"
+import (
+	"fmt"
+	"net"
+	"strconv"
+	"strings"
+	"time"
+
+	"golang.org/x/text/encoding/unicode"
+)
 
 const VERSION string = "2.0.0"     // MineStat version
 const NUM_FIELDS uint8 = 6         // number of values expected from server
@@ -125,12 +129,12 @@ func Init(given_address string, optional_params ...uint16) {
     // SLP 1.7
     if retval != RETURN_CONNFAIL {
       retval = json_request()
-    }
+    }*/
 
     // Bedrock/Pocket Edition
     if !Online && retval != RETURN_SUCCESS {
       retval = bedrock_request()
-    }*/
+    }
   }
 }
 
@@ -301,7 +305,47 @@ func json_request() Status_code {
   return RETURN_UNKNOWN
 }
 
-// ToDo: Implement me.
+
 func bedrock_request() Status_code {
-  return RETURN_UNKNOWN
+  bedrockPort := Port
+  if bedrockPort == DEFAULT_TCP_PORT {
+    bedrockPort = DEFAULT_BEDROCK_PORT
+    // should be changed, because it doesn't support the port being 25565, best for now
+    //fixing this would require a major rewrite
+  }
+
+  conn, err := net.Dial("udp", Address + ":" + strconv.FormatUint(uint64(bedrockPort), 10))
+  Server_socket = conn
+  if err != nil {
+    fmt.Println(err)
+  }
+
+  request := []byte("\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\xff\xff\x00\xfe\xfe\xfe\xfe\xfd\xfd\xfd\xfd\x124Vx")
+  conn.Write(request)
+
+  buffer := make([]byte, 1024)
+  pLen, err := conn.Read(buffer)
+  if err != nil {
+    return RETURN_UNKNOWN
+  }
+
+  conn.Close()
+
+  rawRes := buffer[:pLen]
+  strRes := string(rawRes[35:])
+  splitRes := strings.Split(strRes, ";")
+
+  Online = true
+  Motd = splitRes[1]
+
+  current_players, _ := strconv.ParseUint(splitRes[4], 10, 32)
+	max_players, _ := strconv.ParseUint(splitRes[5], 10, 32)
+  Current_players = uint32(current_players)
+  Max_players = uint32(max_players)
+
+  Version = splitRes[3]
+  Protocol = "Bedrock SLP v" + splitRes[2]
+  // there are a view more values returned by the server
+  // also using them would require a quit large rewrite of the existing codebase
+  return RETURN_SUCCESS
 }


### PR DESCRIPTION
## Proposed Changes
- add support for bedrock servers
- a bit of convention stuff

you can test it using:
- minestat.Init("geo.hivebedrock.network", 19132, 10, minestat.REQUEST_BEDROCK)

Note: the bedrock server sends back some more non standard values, they are currently not used, because this would require a major rewrite of the codebase
