### PR TITLE
Maintenance: Update Github Actions and add Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,24 @@
+version: 2
+updates:
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      # Check for updates to GitHub Actions every week
+      interval: "weekly"
+    labels:
+      - "package management"
+
+  - package-ecosystem: "pip"
+    directory: "/Python"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "lang: Python"
+
+  - package-ecosystem: "gradle"
+    directory: "/Java"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "lang: Java"

--- a/.github/workflows/Maven-publish.yml
+++ b/.github/workflows/Maven-publish.yml
@@ -5,17 +5,23 @@ on:
 
 jobs:
   publish-maven:
+
     runs-on: ubuntu-latest
     defaults:
       run:
         working-directory: Java/
+
     steps:
       - name: Check out Git repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
+
       - name: Install Java and Maven
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v3
         with:
           java-version: 11
+          distribution: 'temurin'
+
+      # TODO: Replace! This action is archived since Jan 2023: https://github.com/samuelmeuli/action-maven-publish
       - name: Publish Maven package
         uses: samuelmeuli/action-maven-publish@v1
         with:

--- a/.github/workflows/PyPI-publish.yml
+++ b/.github/workflows/PyPI-publish.yml
@@ -19,20 +19,25 @@ jobs:
     defaults:
       run:
         working-directory: Python/
+
     steps:
       - uses: actions/checkout@v3
+
       - name: Set up Python
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v4
         with:
           python-version: "3.x"
+
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
           pip install build
+
       - name: Build package
         run: python -m build
+
       - name: Publish package
-        uses: pypa/gh-action-pypi-publish@release/v1.5
+        uses: pypa/gh-action-pypi-publish@release/v1
         with:
           user: __token__
           password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/nuget-publish.yml
+++ b/.github/workflows/nuget-publish.yml
@@ -8,7 +8,7 @@ jobs:
     name: build, pack & publish
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       # - name: Setup dotnet
       #   uses: actions/setup-dotnet@v1
@@ -18,7 +18,7 @@ jobs:
       # Publish
       - name: publish on version change
         id: publish_nuget
-        uses: alirezanet/publish-nuget@v3.0.0
+        uses: alirezanet/publish-nuget@v3.0.4
         with:
           # Filepath of the project to be packaged, relative to root of repository
           PROJECT_FILE_PATH: CSharp/MineStat/MineStat.csproj

--- a/.github/workflows/rubygem-publish.yml
+++ b/.github/workflows/rubygem-publish.yml
@@ -16,10 +16,12 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
+
       - name: Set up Ruby 2.6
-        uses: actions/setup-ruby@v1
+        uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 2.6.x
+          ruby-version: '2.6'
+
       - name: Publish to RubyGems
         run: |
           mkdir -p .gem


### PR DESCRIPTION
## Proposed Changes
- Add [dependabot version update](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/about-dependabot-version-updates) config.
  - Since we now have dependencies in some language variants, we should keep them up to date. After this config file is merged into master, dependabot (**a free service by Github themselves**) will automatically open PRs for dependency updates.
  - With this basic file, the following update checks are enabled:
    - Github Actions
    - Python pip dependencies
    - Java gradle dependencies
- Migrate to [the new `ruby/setup-ruby` GH Action by the `ruby` org themselves](https://github.com/ruby/setup-ruby), away from [the now deprecated and archived `actions/setup-ruby`](https://github.com/actions/setup-ruby#setup-ruby)
- Miscellaneous actions updates
