### PR TITLE
JSON Protocol Is Removing Whitespace In MOTD

### DIFF
--- a/CSharp/MineStat/MineStat.cs
+++ b/CSharp/MineStat/MineStat.cs
@@ -482,6 +482,7 @@ namespace MineStatLib
         var descriptionElement = root.XPathSelectElement("//description");
         // JsonWriter needs a XmlDocument with the root element "root"
         XmlDocument motdJsonDocument = new XmlDocument();
+        motdJsonDocument.PreserveWhitespace = true;
         descriptionElement.Name = "root";
         motdJsonDocument.LoadXml(descriptionElement.ToString());
         MemoryStream tempMotdJsonStream = new MemoryStream();


### PR DESCRIPTION
## Proposed Changes
- Related to https://github.com/FragLand/minestat/issues/172
- Fixed MOTD Stripping tags with empty text, this includes spaces or `\n`
