### PR TITLE
C#: Fixed motd format stripping for nested json formatting

### DIFF
--- a/CSharp/MineStat/MineStat.cs
+++ b/CSharp/MineStat/MineStat.cs
@@ -248,9 +248,11 @@ namespace MineStatLib
       {
         var json_data = rawmotd.Element("extra").Elements();
         foreach (var item in json_data)
-          stripped_motd += item.Element("text")?.Value;
+        {
+          stripped_motd += strip_motd_formatting(item);
+        }
       }
-      return strip_motd_formatting(stripped_motd);
+      return stripped_motd;
     }
 
     /// <summary>


### PR DESCRIPTION
This PR fixes MOTD stripping for nested MOTDs with JSON formatting.


The example server from #172 can be used to test this:
Motd:
![grafik](https://user-images.githubusercontent.com/24863329/221964670-bad0b8a6-0197-418b-bcb4-d3a63eea6c9c.png)

without this patch, the stripped motd is:
```
\n
```

with the patch the value is correct:
```
 sᴍᴘ     ---[-  COMPLEX  GAMING  -]---   ᴘʀɪsᴏɴ\n sᴋʏʙʟᴏᴄᴋ iii #1 1.19 ᴠᴀɴɪʟʟᴀ ɴᴇᴛᴡᴏʀᴋ iii    ғᴀᴄᴛɪᴏɴs
 ```

## Proposed Changes
- Fix MOTD format stripping for deeply nested json formatting codes