### PR TITLE
Python: Fixed double SRV resolution

### DIFF
--- a/Python/.lift.toml
+++ b/Python/.lift.toml
@@ -1,0 +1,1 @@
+ignoreRules = [ "E111" ]

--- a/Python/.lift.toml
+++ b/Python/.lift.toml
@@ -1,1 +1,1 @@
-ignoreRules = [ "E111" ]
+ignoreRules = [ "E111", "E114" ]

--- a/Python/minestat/__init__.py
+++ b/Python/minestat/__init__.py
@@ -210,6 +210,8 @@ class MineStat:
 
         else:
           self.address = addr
+          # Don't change the port if set from SRV record
+          autoport = False
 
     self.port: int = port
     """port number the Minecraft server accepts connections on"""


### PR DESCRIPTION
## Proposed Changes
- Disables the automatic port changes if the first SRV resolution was successful.

I'm going to work on a general logic improvement, so that the whole construct with two SRV resolutions can be thrown out, but that might still take a while (limited time).

This PR/change can be tested with domain `srvtest.fx3.eu`.
Old version: `ms.address=gameserv.ng.fx3.eu`, `ms.port=25565`
New version: `ms.address=gameserv.ng.fx3.eu`. `ms.port=12345`

Fixes #183.