### PR TITLE
feats(JS): Typedefs + promise support

### DIFF
--- a/JavaScript/CHANGELOG.md
+++ b/JavaScript/CHANGELOG.md
@@ -1,4 +1,10 @@
 # 2.0.0
+## Breaking Changes
+- `MineStat#init` is now `MineStat#initSync` to maintain callback functionality
+- A client timeout will not longer end the process
+
+#### All Changes
 - fix(timeout): Resolves issue where if used as library, a timeout would fire `process.exit()` ending the parent app
 - chore(errors): Changes the callback signature to `(error: Error | never, result: Stats) => void`
 - chore(types): Adds typescript definitions
+- feat(promise): Move `init` to `initSync`. `init` now returns a promise

--- a/JavaScript/CHANGELOG.md
+++ b/JavaScript/CHANGELOG.md
@@ -1,0 +1,4 @@
+# 2.0.0
+- fix(timeout): Resolves issue where if used as library, a timeout would fire `process.exit()` ending the parent app
+- chore(errors): Changes the callback signature to `(error: Error | never, result: Stats) => void`
+- chore(types): Adds typescript definitions

--- a/JavaScript/CHANGELOG.md
+++ b/JavaScript/CHANGELOG.md
@@ -2,7 +2,7 @@
 ## Breaking Changes
 - `MineStat#init` is now `MineStat#initSync` to maintain callback functionality
 - Both async + synchronous init methods now take an `options` object as the first argument
-- A client timeout will not longer end the process
+- A client timeout will no longer end the process
 
 #### All Changes
 - fix(timeout): Resolves issue where if used as library, a timeout would fire `process.exit()` ending the parent app

--- a/JavaScript/CHANGELOG.md
+++ b/JavaScript/CHANGELOG.md
@@ -1,6 +1,7 @@
 # 2.0.0
 ## Breaking Changes
 - `MineStat#init` is now `MineStat#initSync` to maintain callback functionality
+- Both async + synchronous init methods now take an `options` object as the first argument
 - A client timeout will not longer end the process
 
 #### All Changes
@@ -8,3 +9,4 @@
 - chore(errors): Changes the callback signature to `(error: Error | never, result: Stats) => void`
 - chore(types): Adds typescript definitions
 - feat(promise): Move `init` to `initSync`. `init` now returns a promise
+- feat(refactor): `init` and `initSync` use an `options` object instead of discrete arguments

--- a/JavaScript/README.md
+++ b/JavaScript/README.md
@@ -6,7 +6,7 @@ MineStat is a Minecraft server status checker.
 Exposes two methods:
 
 #### `ìnitSync`
-- Fetches the server status asyncrhonously, with an optional timeout 
+- Fetches the server status asynchronously, with an optional timeout 
 ```typescript
 init(address: string, port: number): Promise<Stats>;
 init(address: string, port: number, timeout: number): Promise<Stats>;
@@ -56,7 +56,7 @@ For online servers:
     {
       console.log("Server is online running version " + result.version + " with " + result.current_players + " out of " + result.max_players + " players.");
       console.log("Message of the day: " + result.motd);
-      console.log("Latency: " + result.latency + "result");
+      console.log("Latency: " + result.latency + "ms");
     }
     else
     {
@@ -77,7 +77,7 @@ ms.initSync({address: 'minecraft.frag.land', port: 12345}, function(result)
   {
     console.log("Server is online running version " + result.version + " with " + result.current_players + " out of " + result.max_players + " players.");
     console.log("Message of the day: " + result.motd);
-    console.log("Latency: " + result.latency + "result");
+    console.log("Latency: " + result.latency + "ms");
   }
   else
   {

--- a/JavaScript/README.md
+++ b/JavaScript/README.md
@@ -3,10 +3,74 @@ MineStat
 
 MineStat is a Minecraft server status checker.
 
-### JavaScript example
+Exposes two methods:
+
+#### `ìnitSync`
+- Fetches the server status asyncrhonously, with an optional timeout 
+```typescript
+init(address: string, port: number): Promise<Stats>;
+init(address: string, port: number, timeout: number): Promise<Stats>;
+```
+
+#### `ìnitSync`
+- Synchronously fetches the server status, using a callback, with an optional timeout 
+```typescript
+initSync(address: string, port: number, callback: (error?: Error, result: Stats) => void): void;
+init(address: string, port: number, timeout: number, callback: (error?: Error, result: Stats) => void): void;
+```
+
+Returns a `Stats` object. For offline server statuses:
+```typescript
+{
+  address: string; // The original address you provided
+  port: number; // The original port you provided
+  latency: number; // Ping to server in ms
+  offline: false;
+}
+```
+
+For online servers:
+```typescript
+{
+  address: string;
+  port: number;
+  latency: number;
+  online: true;
+  version: string;
+  max_players: number;
+  current_players: number;
+  motd: string; // Message of the day
+}
+```
+
+
+
+### JavaScript async example
+```javascript
+  const ms = require('minestat');
+
+  try {
+    const result = await ms.init('minecraft.frag.land', 25565);
+    console.log("Minecraft server status of " + result.address + " on port " + result.port + ":");
+    if(result.online)
+    {
+      console.log("Server is online running version " + result.version + " with " + result.current_players + " out of " + result.max_players + " players.");
+      console.log("Message of the day: " + result.motd);
+      console.log("Latency: " + result.latency + "result");
+    }
+    else
+    {
+      console.log("Server is offline!");
+    }
+  } catch (error) {
+    throw error;
+  }
+```
+
+### JavaScript synchronous example
 ```javascript
 var ms = require('minestat');
-ms.init('minecraft.frag.land', 25565, function(result)
+ms.initSync('minecraft.frag.land', 25565, function(result)
 {
   console.log("Minecraft server status of " + result.address + " on port " + result.port + ":");
   if(result.online)
@@ -20,5 +84,5 @@ ms.init('minecraft.frag.land', 25565, function(result)
     console.log("Server is offline!");
   }
 });
-
 ```
+

--- a/JavaScript/README.md
+++ b/JavaScript/README.md
@@ -50,7 +50,7 @@ For online servers:
   const ms = require('minestat');
 
   try {
-    const result = await ms.init('minecraft.frag.land', 25565);
+    const result = await ms.init({address: 'minecraft.frag.land'});
     console.log("Minecraft server status of " + result.address + " on port " + result.port + ":");
     if(result.online)
     {
@@ -70,7 +70,7 @@ For online servers:
 ### JavaScript synchronous example
 ```javascript
 var ms = require('minestat');
-ms.initSync('minecraft.frag.land', 25565, function(result)
+ms.initSync({address: 'minecraft.frag.land', port: 12345}, function(result)
 {
   console.log("Minecraft server status of " + result.address + " on port " + result.port + ":");
   if(result.online)

--- a/JavaScript/README.md
+++ b/JavaScript/README.md
@@ -5,7 +5,7 @@ MineStat is a Minecraft server status checker.
 
 Exposes two methods:
 
-#### `ìnitSync`
+#### `ìnit`
 - Fetches the server status asynchronously, with an optional timeout 
 ```typescript
 init(address: string, port: number): Promise<Stats>;
@@ -43,14 +43,13 @@ For online servers:
 }
 ```
 
-
-
 ### JavaScript async example
 ```javascript
-  const ms = require('minestat');
-
-  try {
-    const result = await ms.init({address: 'minecraft.frag.land'});
+const ms = require('minestat');
+(async () => {
+  try
+  {
+    const result = await ms.init({address: 'minecraft.frag.land', port: 25565});
     console.log("Minecraft server status of " + result.address + " on port " + result.port + ":");
     if(result.online)
     {
@@ -62,15 +61,18 @@ For online servers:
     {
       console.log("Server is offline!");
     }
-  } catch (error) {
+  }
+  catch(error)
+  {
     throw error;
   }
+})();
 ```
 
 ### JavaScript synchronous example
 ```javascript
 var ms = require('minestat');
-ms.initSync({address: 'minecraft.frag.land', port: 12345}, function(result)
+ms.initSync({address: 'minecraft.frag.land', port: 25565}, function(result)
 {
   console.log("Minecraft server status of " + result.address + " on port " + result.port + ":");
   if(result.online)
@@ -85,4 +87,3 @@ ms.initSync({address: 'minecraft.frag.land', port: 12345}, function(result)
   }
 });
 ```
-

--- a/JavaScript/example.js
+++ b/JavaScript/example.js
@@ -1,8 +1,10 @@
+// Synchronous example (see example-async.js or example-async.mjs for asynchronous examples)
 var ms = require('minestat');
-ms.init('minecraft.frag.land', 25565, function(error, result)
+ms.initSync({address: 'minecraft.frag.land', port: 25565}, function(error, result)
 {
-  if (error) {
-    console.log('The request timed out');
+  if(error)
+  {
+    console.log('Error encountered during connection attempt.');
     throw error;
   }
 
@@ -11,7 +13,7 @@ ms.init('minecraft.frag.land', 25565, function(error, result)
   {
     console.log("Server is online running version " + result.version + " with " + result.current_players + " out of " + result.max_players + " players.");
     console.log("Message of the day: " + result.motd);
-    console.log("Latency: " + result.latency + "result");
+    console.log("Latency: " + result.latency + "ms");
   }
   else
   {

--- a/JavaScript/example.js
+++ b/JavaScript/example.js
@@ -1,6 +1,11 @@
 var ms = require('minestat');
-ms.init('minecraft.frag.land', 25565, function(result)
+ms.init('minecraft.frag.land', 25565, function(error, result)
 {
+  if (error) {
+    console.log('The request timed out');
+    throw error;
+  }
+
   console.log("Minecraft server status of " + result.address + " on port " + result.port + ":");
   if(result.online)
   {

--- a/JavaScript/index.d.ts
+++ b/JavaScript/index.d.ts
@@ -30,9 +30,15 @@ declare module 'minestat' {
     (address: string, port: number, timeout: number, callback: Callback): void;
   }
 
+  interface AsyncInit {
+    (address: string, port: number): Promise<Stats>;
+    (address: string, port: number, timeout: number): Promise<Stats>;
+  }
+
   interface MineStat {
     VERSION: string;
-    init: InitFn;
+    init: AsyncInit;
+    initSync: InitFn;
   }
 
   const minestat: MineStat;

--- a/JavaScript/index.d.ts
+++ b/JavaScript/index.d.ts
@@ -1,0 +1,41 @@
+declare module 'minestat' {
+
+  type BaseStats<T, U> = {
+    address: T;
+    port: U;
+    latency: number;
+  };
+
+  type Online<T, U> = BaseStats<T, U> & {
+    online: true;
+    version: string;
+    max_players: number;
+    current_players: number;
+    motd: string;
+  };
+
+  type Offline<T, U> = BaseStats<T, U> & {
+    online: false;
+  };
+
+  type Stats<T, U> = Readonly<Online<T, U> | Offline<T, U>>;
+
+  interface Callback<T, U> {
+    (error: Error): void;
+    (error: never, result: Stats<T, U>): void;
+  }
+
+  interface InitFn {
+    (address: string, port: number, callback: Callback<typeof address, typeof port>): void;
+    (address: string, port: number, timeout: number, callback: Callback<typeof address, typeof port>): void;
+  }
+
+  interface MineStat {
+    VERSION: string;
+    init: InitFn;
+  }
+
+  const minestat: MineStat;
+
+  export = minestat;
+}

--- a/JavaScript/index.d.ts
+++ b/JavaScript/index.d.ts
@@ -1,12 +1,12 @@
 declare module 'minestat' {
 
-  type BaseStats<T, U> = {
-    address: T;
-    port: U;
+  type BaseStats = {
+    address: string;
+    port: number;
     latency: number;
   };
 
-  type Online<T, U> = BaseStats<T, U> & {
+  type Online = BaseStats & {
     online: true;
     version: string;
     max_players: number;
@@ -14,20 +14,20 @@ declare module 'minestat' {
     motd: string;
   };
 
-  type Offline<T, U> = BaseStats<T, U> & {
+  type Offline = BaseStats & {
     online: false;
   };
 
-  type Stats<T, U> = Readonly<Online<T, U> | Offline<T, U>>;
+  type Stats = Readonly<Online | Offline>;
 
-  interface Callback<T, U> {
+  interface Callback {
     (error: Error): void;
-    (error: never, result: Stats<T, U>): void;
+    (error: never, result: Stats): void;
   }
 
   interface InitFn {
-    (address: string, port: number, callback: Callback<typeof address, typeof port>): void;
-    (address: string, port: number, timeout: number, callback: Callback<typeof address, typeof port>): void;
+    (address: string, port: number, callback: Callback): void;
+    (address: string, port: number, timeout: number, callback: Callback): void;
   }
 
   interface MineStat {

--- a/JavaScript/index.d.ts
+++ b/JavaScript/index.d.ts
@@ -25,15 +25,14 @@ declare module 'minestat' {
     (error: never, result: Stats): void;
   }
 
-  interface InitFn {
-    (address: string, port: number, callback: Callback): void;
-    (address: string, port: number, timeout: number, callback: Callback): void;
+  interface Options {
+    address: string;
+    port: number;
+    timeout?: number;
   }
 
-  interface AsyncInit {
-    (address: string, port: number): Promise<Stats>;
-    (address: string, port: number, timeout: number): Promise<Stats>;
-  }
+  type InitFn = (options: Options, callback: Callback) => void;
+  type AsyncInit = (options: Options) => Promise<Stats>;
 
   interface MineStat {
     VERSION: string;

--- a/JavaScript/minestat.js
+++ b/JavaScript/minestat.js
@@ -22,24 +22,15 @@
 
 const VERSION = "2.0.0";   // MineStat version
 const NUM_FIELDS = 6;      // number of values expected from server
-const DEFAULT_TIMEOUT = 5; // default TCP timeout in seconds
-address = null;
-port = null;
-online = null;             // online or offline?
-version = null;            // server version
-motd = null;               // message of the day
-current_players = null;    // current number of players online
-max_players = null;        // maximum player capacity
-latency = null;            // ping time to server in milliseconds
+const DEFAULT_TIMEOUT = 5000;
 
-function init(opts, callback)
+function func(opts, callback)
 {
+  const {address, port = 25565, timeout = DEFAULT_TIMEOUT} = opts;
   var res = {};
-  res.address = opts.address;
-  res.port = opts.port || 25565;
+  res.address = address;
+  res.port = port;
   res.online = false;
-
-  const timeout = opts.timeout || DEFAULT_TIMEOUT;
 
   const net = require('net');
   var start_time = new Date();
@@ -50,7 +41,7 @@ function init(opts, callback)
     client.write(buff);
   });
 
-  client.setTimeout(timeout * 1000);
+  client.setTimeout(timeout);
 
   client.on('data', (data) =>
   {
@@ -117,7 +108,7 @@ module.exports =
     init: async function(opts) {
       return new Promise(function(resolve, reject)
       {
-        init(opts, (error, result) => {
+        func(opts, (error, result) => {
           if (error) {
             reject(error);
           } else {
@@ -128,6 +119,6 @@ module.exports =
     },
     initSync: function(opts, callback)
     {
-      return init(opts, callback);
+      return func(opts, callback);
     }
   };

--- a/JavaScript/minestat.js
+++ b/JavaScript/minestat.js
@@ -20,13 +20,14 @@
 
 // For use with Node.js
 
-const VERSION = "2.0.0";   // MineStat version
-const NUM_FIELDS = 6;      // number of values expected from server
-const DEFAULT_TIMEOUT = 5000;
+const VERSION = "2.0.0";    // MineStat version
+const NUM_FIELDS = 6;       // number of values expected from server
+const DEFAULT_PORT = 25565; // default TCP port of Minecraft server
+const DEFAULT_TIMEOUT = 5;  // default TCP timeout in seconds
 
 function func(opts, callback)
 {
-  const {address, port = 25565, timeout = DEFAULT_TIMEOUT} = opts;
+  const {address, port = DEFAULT_PORT, timeout = DEFAULT_TIMEOUT * 1000} = opts;
   var res = {};
   res.address = address;
   res.port = port;

--- a/JavaScript/minestat.js
+++ b/JavaScript/minestat.js
@@ -27,7 +27,7 @@ const DEFAULT_TIMEOUT = 5;  // default TCP timeout in seconds
 
 function func(opts, callback)
 {
-  const {address, port = DEFAULT_PORT, timeout = DEFAULT_TIMEOUT * 1000} = opts;
+  const {address, port = DEFAULT_PORT, timeout = DEFAULT_TIMEOUT} = opts;
   var res = {};
   res.address = address;
   res.port = port;
@@ -42,7 +42,7 @@ function func(opts, callback)
     client.write(buff);
   });
 
-  client.setTimeout(timeout);
+  client.setTimeout(timeout * 1000);
 
   client.on('data', (data) =>
   {

--- a/JavaScript/minestat.js
+++ b/JavaScript/minestat.js
@@ -20,7 +20,7 @@
 
 // For use with Node.js
 
-const VERSION = "1.0.4";   // MineStat version
+const VERSION = "2.0.0";   // MineStat version
 const NUM_FIELDS = 6;      // number of values expected from server
 const DEFAULT_TIMEOUT = 5; // default TCP timeout in seconds
 address = null;
@@ -32,90 +32,104 @@ current_players = null;    // current number of players online
 max_players = null;        // maximum player capacity
 latency = null;            // ping time to server in milliseconds
 
+const init = (address, port, timeout, callback) => {
+  var res = {};
+  res.address = address;
+  res.port = port;
+  res.online = false;
+
+  // if 3rd argument is a function, it's the callback (timeout is optional)
+  if(typeof(timeout) === typeof(Function()))
+  {
+    callback = timeout;
+    timeout = DEFAULT_TIMEOUT;
+  }
+
+  const net = require('net');
+  var start_time = new Date();
+  const client = net.connect(port, address, () =>
+  {
+    res.latency = Math.round(new Date() - start_time);
+    var buff = Buffer.from([ 0xFE, 0x01 ]);
+    client.write(buff);
+  });
+
+  client.setTimeout(timeout * 1000);
+
+  client.on('data', (data) =>
+  {
+    if(data != null && data != '')
+    {
+      var server_info = data.toString().split("\x00\x00\x00");
+      if(server_info != null && server_info.length >= NUM_FIELDS)
+      {
+        res.online = true;
+        res.version = server_info[2].replace(/\u0000/g,'');
+        res.motd = server_info[3].replace(/\u0000/g,'');
+        res.current_players = Number(server_info[4].replace(/\u0000/g,''));
+        res.max_players = Number(server_info[5].replace(/\u0000/g,''));
+      }
+      else
+      {
+        res.online = false;
+      }
+    }
+    callback(undefined, res);
+    client.end();
+  });
+
+  client.on('timeout', () =>
+  {
+    callback(new Error('Client timed out during request'));
+    client.end();
+  });
+
+  client.on('end', () =>
+  {
+    // nothing needed here
+  });
+
+  client.on('error', (err) =>
+  {
+    // Uncomment the lines below to handle error codes individually. Otherwise,
+    // call callback() and simply report the remote server as being offline.
+
+    /*
+    if(err.code == "ENOTFOUND")
+    {
+      console.log("Unable to resolve " + res.address + ".");
+      return;
+    }
+
+    if(err.code == "ECONNREFUSED")
+    {
+      console.log("Unable to connect to port " + res.port + ".");
+      return;
+    }
+    */
+
+    callback(err);
+
+    // Uncomment the line below for more details pertaining to network errors.
+    //console.log(err);
+  });
+}
+
 module.exports =
   {
     VERSION: VERSION,
-    init: function(address, port, timeout, callback)
-    {
-      var res = {};
-      res.address = address;
-      res.port = port;
-      res.online = false;
-
-      // if 3rd argument is a function, it's the callback (timeout is optional)
-      if(typeof(timeout) === typeof(Function()))
-      {
-        callback = timeout;
-        timeout = DEFAULT_TIMEOUT;
-      }
-
-      const net = require('net');
-      var start_time = new Date();
-      const client = net.connect(port, address, () =>
-      {
-        res.latency = Math.round(new Date() - start_time);
-        var buff = Buffer.from([ 0xFE, 0x01 ]);
-        client.write(buff);
-      });
-
-      client.setTimeout(timeout * 1000);
-
-      client.on('data', (data) =>
-      {
-        if(data != null && data != '')
-        {
-          var server_info = data.toString().split("\x00\x00\x00");
-          if(server_info != null && server_info.length >= NUM_FIELDS)
-          {
-            res.online = true;
-            res.version = server_info[2].replace(/\u0000/g,'');
-            res.motd = server_info[3].replace(/\u0000/g,'');
-            res.current_players = Number(server_info[4].replace(/\u0000/g,''));
-            res.max_players = Number(server_info[5].replace(/\u0000/g,''));
+    init: async function(address, port, timeout) {
+      return new Promise((resolve, reject) => {
+        init(address, port, timeout, (error, result) => {
+          if (error) {
+            reject(error);
+          } else {
+            resolve(result);
           }
-          else
-          {
-            res.online = false;
-          }
-        }
-        callback(undefined, res);
-        client.end();
+        });
       });
-
-      client.on('timeout', () =>
-      {
-        callback(new Error('Client timed out during request'));
-        client.end();
-      });
-
-      client.on('end', () =>
-      {
-        // nothing needed here
-      });
-
-      client.on('error', (err) =>
-      {
-        // Uncomment the lines below to handle error codes individually. Otherwise,
-        // call callback() and simply report the remote server as being offline.
-
-        /*
-        if(err.code == "ENOTFOUND")
-        {
-          console.log("Unable to resolve " + res.address + ".");
-          return;
-        }
-
-        if(err.code == "ECONNREFUSED")
-        {
-          console.log("Unable to connect to port " + res.port + ".");
-          return;
-        }
-        */
-
-        callback(err);
-
-        // Uncomment the line below for more details pertaining to network errors.
-        //console.log(err);
-      });
+    },
+    initSync: function(address, port, timeout, callback) {
+      return init(address, port, timeout, callback);
     }
   };

--- a/JavaScript/minestat.js
+++ b/JavaScript/minestat.js
@@ -78,15 +78,14 @@ module.exports =
             res.online = false;
           }
         }
-        callback(res);
+        callback(undefined, res);
         client.end();
       });
 
       client.on('timeout', () =>
       {
-        callback();
+        callback(new Error('Client timed out during request'));
         client.end();
-        process.exit();
       });
 
       client.on('end', () =>

--- a/JavaScript/minestat.js
+++ b/JavaScript/minestat.js
@@ -104,22 +104,27 @@ function func(opts, callback)
 }
 
 module.exports =
+{
+  VERSION: VERSION,
+  init: async function(opts)
   {
-    VERSION: VERSION,
-    init: async function(opts) {
-      return new Promise(function(resolve, reject)
-      {
-        func(opts, (error, result) => {
-          if (error) {
-            reject(error);
-          } else {
-            resolve(result);
-          }
-        });
-      });
-    },
-    initSync: function(opts, callback)
+    return new Promise(function(resolve, reject)
     {
-      return func(opts, callback);
-    }
-  };
+      func(opts, (error, result) =>
+      {
+        if(error)
+        {
+          reject(error);
+        }
+        else
+        {
+          resolve(result);
+        }
+      });
+    });
+  },
+  initSync: function(opts, callback)
+  {
+    return func(opts, callback);
+  }
+};

--- a/JavaScript/minestat.js
+++ b/JavaScript/minestat.js
@@ -32,18 +32,13 @@ current_players = null;    // current number of players online
 max_players = null;        // maximum player capacity
 latency = null;            // ping time to server in milliseconds
 
-const init = (address, port, timeout, callback) => {
+const init = (opts, callback) => {
   var res = {};
-  res.address = address;
-  res.port = port;
+  res.address = opts.address;
+  res.port = opts.port || 25565;
   res.online = false;
 
-  // if 3rd argument is a function, it's the callback (timeout is optional)
-  if(typeof(timeout) === typeof(Function()))
-  {
-    callback = timeout;
-    timeout = DEFAULT_TIMEOUT;
-  }
+  const timeout = opts.timeout || DEFAULT_TIMEOUT;
 
   const net = require('net');
   var start_time = new Date();
@@ -118,9 +113,9 @@ const init = (address, port, timeout, callback) => {
 module.exports =
   {
     VERSION: VERSION,
-    init: async function(address, port, timeout) {
+    init: async function(opts) {
       return new Promise((resolve, reject) => {
-        init(address, port, timeout, (error, result) => {
+        init(opts, (error, result) => {
           if (error) {
             reject(error);
           } else {
@@ -129,7 +124,7 @@ module.exports =
         });
       });
     },
-    initSync: function(address, port, timeout, callback) {
-      return init(address, port, timeout, callback);
+    initSync: function(opts, callback) {
+      return init(opts, callback);
     }
   };

--- a/JavaScript/minestat.js
+++ b/JavaScript/minestat.js
@@ -1,6 +1,6 @@
 /*
  * minestat.js - A Minecraft server status checker
- * Copyright (C) 2016, 2022 Lloyd Dilley
+ * Copyright (C) 2016, 2022 Lloyd Dilley, 2023 Kolya Venturi
  * http://www.dilley.me/
  *
  * This program is free software; you can redistribute it and/or modify

--- a/JavaScript/minestat.js
+++ b/JavaScript/minestat.js
@@ -32,7 +32,8 @@ current_players = null;    // current number of players online
 max_players = null;        // maximum player capacity
 latency = null;            // ping time to server in milliseconds
 
-const init = (opts, callback) => {
+function init(opts, callback)
+{
   var res = {};
   res.address = opts.address;
   res.port = opts.port || 25565;
@@ -114,7 +115,8 @@ module.exports =
   {
     VERSION: VERSION,
     init: async function(opts) {
-      return new Promise((resolve, reject) => {
+      return new Promise(function(resolve, reject)
+      {
         init(opts, (error, result) => {
           if (error) {
             reject(error);
@@ -124,7 +126,8 @@ module.exports =
         });
       });
     },
-    initSync: function(opts, callback) {
+    initSync: function(opts, callback)
+    {
       return init(opts, callback);
     }
   };

--- a/JavaScript/package.json
+++ b/JavaScript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "minestat",
-  "version": "1.0.5",
+  "version": "2.0.0",
   "description": "A Minecraft server status checker",
   "main": "minestat.js",
   "types": "index.d.ts",
@@ -17,6 +17,20 @@
     "checker"
   ],
   "author": "Lloyd Dilley",
+  "contributors": [
+    {
+      "name": "ThisTNTSquid"
+    },
+    {
+      "name": "seia-soto"
+    },
+    {
+      "name": "RunTheBot"
+    },
+    {
+      "name": "Kolya Venturi"
+    }
+  ],
   "license": "GPL-3.0",
   "bugs": {
     "url": "https://github.com/FragLand/minestat/issues"

--- a/JavaScript/package.json
+++ b/JavaScript/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.5",
   "description": "A Minecraft server status checker",
   "main": "minestat.js",
+  "types": "index.d.ts",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },


### PR DESCRIPTION
## Proposed Changes
- Adds type definitions
- Adds changelog
- (breaking): Adds `init` as an async method, moves callback to `initSync`
- (breaking): Migrates discrete arguments to be a single `{address: string, port: number, timeout?: number}` object
- (breaking): Removes the `process.exit()` line which would kill parents apps if used as a library (ref: #10)
