### PR TITLE
Ruby: Empty MotD fix

### DIFF
--- a/Ruby/ChangeLog.md
+++ b/Ruby/ChangeLog.md
@@ -1,3 +1,9 @@
+## 3.0.3 (November 2, 2023)
+- Fixed empty MotD issue
+
+## 3.0.2 (February 20, 2023)
+- Added field (srv_succeeded) to indicate whether DNS SRV resolution was successful
+
 ## 3.0.1 (February 5, 2023)
 - Added configurable DNS SRV resolution
 - Added request type that attempts all SLP protocols

--- a/Ruby/lib/minestat.rb
+++ b/Ruby/lib/minestat.rb
@@ -27,7 +27,7 @@ require 'timeout'
 # Provides a Ruby interface for polling the status of Minecraft servers
 class MineStat
   # MineStat version
-  VERSION = "3.0.2"
+  VERSION = "3.0.3"
 
   # Number of values expected from server
   NUM_FIELDS = 6

--- a/Ruby/lib/minestat.rb
+++ b/Ruby/lib/minestat.rb
@@ -255,7 +255,8 @@ class MineStat
   # Strips message of the day formatting characters
   def strip_motd()
     unless @motd['text'] == nil
-      @stripped_motd = @motd['text']
+      @motd = @motd['text']
+      @stripped_motd = @motd
     else
       @stripped_motd = @motd
     end

--- a/Ruby/minestat.gemspec
+++ b/Ruby/minestat.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name = "minestat"
-  spec.version = "3.0.2"
+  spec.version = "3.0.3"
   spec.authors = ["Lloyd Dilley"]
   spec.email = ["minecraft@frag.land"]
   spec.summary = "Minecraft server status checker"


### PR DESCRIPTION
## Proposed Changes
- Fix empty MotD (related to #200).
- Increment version from `3.0.2` to `3.0.3`.
- Update changelog.
