### PR TITLE
Java: Empty MotD fix for JSON

### DIFF
--- a/Java/me/dilley/MineStat.java
+++ b/Java/me/dilley/MineStat.java
@@ -749,15 +749,23 @@ public class MineStat
       // Populate object from JSON data
       JsonObject jobj = new Gson().fromJson(new String(rawData), JsonObject.class);
       setProtocol(jobj.get("version").getAsJsonObject().get("protocol").getAsInt());
-      setMotd(jobj.get("description").getAsString());
-      try
+
+      if(!jobj.has("description"))
       {
-        setStrippedMotd(stripMotdFormatting(jobj.get("description").getAsJsonObject()));
+        setMotd("");
+        setStrippedMotd("");
       }
-      catch(Exception e)
+      else if(jobj.get("description").isJsonPrimitive())
       {
+        setMotd(jobj.get("description").getAsString());
         setStrippedMotd(stripMotdFormatting(jobj.get("description").getAsString()));
       }
+      else
+      {
+        setMotd(jobj.get("description").toString());
+        setStrippedMotd(stripMotdFormatting(jobj.get("description").getAsJsonObject()));
+      }
+
       setVersion(jobj.get("version").getAsJsonObject().get("name").getAsString());
       setCurrentPlayers(jobj.get("players").getAsJsonObject().get("online").getAsInt());
       setMaximumPlayers(jobj.get("players").getAsJsonObject().get("max").getAsInt());

--- a/Java/me/dilley/MineStat.java
+++ b/Java/me/dilley/MineStat.java
@@ -281,44 +281,9 @@ public class MineStat
 
   public void setMotd(String motd) { this.motd = motd; }
 
-  public String getStrippedMotd() {
-    return strippedMotd;
-  }
+  public String getStrippedMotd() { return strippedMotd; }
 
-  public void setStrippedMotd(String strippedMotd) {
-    this.strippedMotd = strippedMotd;
-  }
-
-  /**
-   * Helper function for stripping any formatting from a motd.
-   * @param motd A motd with formatting codes
-   * @return A motd with all formatting codes removed
-   * @since 2.1.0
-   */
-  public String stripMotdFormatting(String motd) {
-    return motd.replaceAll("§.", "");
-  }
-
-  public String stripMotdFormatting(JsonObject motd) {
-    StringBuilder strippedMotd = new StringBuilder();
-
-    if(motd.isJsonPrimitive()) {
-      return motd.getAsString();
-    }
-
-    JsonObject motdObj = motd.getAsJsonObject();
-    if(motdObj.has("text")) {
-      strippedMotd.append(motdObj.get("text").getAsString());
-    }
-
-    if(motdObj.has("extra") && motdObj.get("extra").isJsonArray()) {
-      for(JsonElement extraElem : motdObj.get("extra").getAsJsonArray()) {
-        strippedMotd.append(stripMotdFormatting(extraElem.getAsJsonObject()));
-      }
-    }
-
-    return strippedMotd.toString();
-  }
+  public void setStrippedMotd(String strippedMotd) { this.strippedMotd = strippedMotd; }
 
   public String getVersion() { return version; }
 
@@ -355,7 +320,39 @@ public class MineStat
   public void setRequestType(String requestType) { this.requestType = requestType; }
 
   public ConnectionStatus getConnectionStatus() { return connectionStatus; }
+
   public String getConnectionStatusDescription() { return connectionStatus.toString(); }
+
+  /**
+   * Helper function for stripping any formatting from a motd.
+   * @param motd A motd with formatting codes
+   * @return A motd with all formatting codes removed
+   * @since 2.1.0
+   */
+  public String stripMotdFormatting(String motd)
+  {
+    return motd.replaceAll("§.", "");
+  }
+
+  public String stripMotdFormatting(JsonObject motd)
+  {
+    StringBuilder strippedMotd = new StringBuilder();
+
+    if(motd.isJsonPrimitive())
+      return motd.getAsString();
+
+    JsonObject motdObj = motd.getAsJsonObject();
+    if(motdObj.has("text"))
+      strippedMotd.append(motdObj.get("text").getAsString());
+
+    if(motdObj.has("extra") && motdObj.get("extra").isJsonArray())
+    {
+      for(JsonElement extraElem : motdObj.get("extra").getAsJsonArray())
+        strippedMotd.append(stripMotdFormatting(extraElem.getAsJsonObject()));
+    }
+
+    return strippedMotd.toString();
+  }
 
   /*
    * 1.8b/1.3

--- a/Java/me/dilley/MineStat.java
+++ b/Java/me/dilley/MineStat.java
@@ -34,7 +34,7 @@ import java.util.Date;
 
 public class MineStat
 {
-  public static final String VERSION = "3.0.5";         // MineStat version
+  public static final String VERSION = "3.0.6";         // MineStat version
   public static final byte NUM_FIELDS = 6;              // number of values expected from server
   public static final byte NUM_FIELDS_BETA = 3;         // number of values expected from a 1.8b/1.3 server
   public static final int DEFAULT_TIMEOUT = 5;          // default TCP/UDP timeout in seconds

--- a/Java/me/dilley/MineStat.java
+++ b/Java/me/dilley/MineStat.java
@@ -749,14 +749,14 @@ public class MineStat
       // Populate object from JSON data
       JsonObject jobj = new Gson().fromJson(new String(rawData), JsonObject.class);
       setProtocol(jobj.get("version").getAsJsonObject().get("protocol").getAsInt());
-      setMotd(jobj.get("description").toString());
+      setMotd(jobj.get("description").getAsString());
       try
       {
         setStrippedMotd(stripMotdFormatting(jobj.get("description").getAsJsonObject()));
       }
       catch(Exception e)
       {
-        setStrippedMotd(stripMotdFormatting(jobj.get("description").toString()));
+        setStrippedMotd(stripMotdFormatting(jobj.get("description").getAsString()));
       }
       setVersion(jobj.get("version").getAsJsonObject().get("name").getAsString());
       setCurrentPlayers(jobj.get("players").getAsJsonObject().get("online").getAsInt());

--- a/Java/pom.xml
+++ b/Java/pom.xml
@@ -4,7 +4,7 @@
   <name>MineStat</name>
   <groupId>io.github.fragland</groupId>
   <artifactId>MineStat</artifactId>
-  <version>3.0.5</version>
+  <version>3.0.6</version>
   <packaging>jar</packaging>
   <description>MineStat is a Minecraft server status checker.</description>
   <url>https://github.com/fragland/minestat</url>


### PR DESCRIPTION
## Proposed Changes
- Adjust MotD strip code to conform to project style.
- Fix empty MotD displaying a pair of double quotes when using SLP 1.7 (JSON) (related to #203).
- Increment version from `3.0.5` to `3.0.6`.
