### PR TITLE
Python: Fix installation on Python 3.6

### DIFF
--- a/Python/requirements.txt
+++ b/Python/requirements.txt
@@ -1,1 +1,1 @@
-dnspython ~= 2.4.2
+dnspython >= 2.2.1,< 2.6.0

--- a/Python/setup.cfg
+++ b/Python/setup.cfg
@@ -20,4 +20,4 @@ classifiers =
 packages = find:
 python_requires = >=3.6
 install_requires = 
-    dnspython >= 2.2.1,< 2.5.0
+    dnspython >= 2.2.1,< 2.6.0


### PR DESCRIPTION
We advertise support for Python 3.6, but the version format in the `requirements.txt` file caused installations there to fail, because dnspython is not available for Python 3.6 after versio 2.2.1.
This PR fixes that by allowing falling back down to 2.2.1, but "bubbling up" to the newest version of dnspython (currently 2.5).