### PR TITLE
Improve comments, indents and pom.xml

### DIFF
--- a/Java/Test/me/dilley/MineStatTest.java
+++ b/Java/Test/me/dilley/MineStatTest.java
@@ -10,65 +10,65 @@ import org.junit.Test;
 
 public class MineStatTest
 {
-	@Test
-	// Tests if address is correct
-	public void checkAddress()
-    {
-		MineStat ms = new MineStat("minecraft.frag.land", 25565);
-		ms.setAddress("minecraft.frag.land");
-		assertEquals("minecraft.frag.land", ms.getAddress());
-	}
+  @Test
+  // Tests if address is correct
+  public void checkAddress()
+  {
+    MineStat ms = new MineStat("minecraft.frag.land", 25565);
+    ms.setAddress("minecraft.frag.land");
+    assertEquals("minecraft.frag.land", ms.getAddress());
+  }
 
-	@Test
-	// Tests if port number is correct
-	public void checkPort()
-    {
-		MineStat ms = new MineStat("minecraft.frag.land", 25565);
-		ms.setPort(25565);
-		assertEquals(25565, ms.getPort());
-	}
+  @Test
+  // Tests if port number is correct
+  public void checkPort()
+  {
+    MineStat ms = new MineStat("minecraft.frag.land", 25565);
+    ms.setPort(25565);
+    assertEquals(25565, ms.getPort());
+  }
 
-	@Test
-	// Tests if version number is correct
-	public void checkVersion()
-    {
-		MineStat ms = new MineStat("minecraft.frag.land", 25565);
-		ms.setVersion("BungeeCord 1.8.x-1.12.x");
-		assertEquals("BungeeCord 1.8.x-1.12.x", ms.getVersion());
-	}
+  @Test
+  // Tests if version number is correct
+  public void checkVersion()
+  {
+    MineStat ms = new MineStat("minecraft.frag.land", 25565);
+    ms.setVersion("BungeeCord 1.8.x-1.12.x");
+    assertEquals("BungeeCord 1.8.x-1.12.x", ms.getVersion());
+  }
 
-	@Test
-	// Tests if number of current players is correct
-	public void checkNumberOfCurrentPlayers()
-    {
-		MineStat ms = new MineStat("minecraft.frag.land", 25565);
-		ms.setCurrentPlayers(0);
-		assertEquals(0, ms.getCurrentPlayers());
-	}
+  @Test
+  // Tests if number of current players is correct
+  public void checkNumberOfCurrentPlayers()
+  {
+    MineStat ms = new MineStat("minecraft.frag.land", 25565);
+    ms.setCurrentPlayers(0);
+    assertEquals(0, ms.getCurrentPlayers());
+  }
 
-	@Test
-	// Tests if number of maximum players is correct
-	public void checkNumberOfMaximumPlayers()
-    {
-		MineStat ms = new MineStat("minecraft.frag.land", 25565);
-		ms.setMaximumPlayers(32);
-		assertEquals(32, ms.getMaximumPlayers());
-	}
+  @Test
+  // Tests if number of maximum players is correct
+  public void checkNumberOfMaximumPlayers()
+  {
+    MineStat ms = new MineStat("minecraft.frag.land", 25565);
+    ms.setMaximumPlayers(32);
+    assertEquals(32, ms.getMaximumPlayers());
+  }
 
-	@Test
-	// Tests if the message of the day is correct
-	public void checkMessageOfTheDay()
-    {
-		MineStat ms = new MineStat("minecraft.frag.land", 25565);
-		ms.setMotd("Frag Land");
-		assertEquals("Frag Land", ms.getMotd());
-	}
+  @Test
+  // Tests if the message of the day is correct
+  public void checkMessageOfTheDay()
+  {
+    MineStat ms = new MineStat("minecraft.frag.land", 25565);
+    ms.setMotd("Frag Land");
+    assertEquals("Frag Land", ms.getMotd());
+  }
 
-	@Test
-	// Tests if the server is up
-	public void checkThatServerIsUp()
-    {
-		MineStat ms = new MineStat("minecraft.frag.land", 25565);
-		assertTrue(ms.isServerUp());
-	}
+  @Test
+  // Tests if the server is up
+  public void checkThatServerIsUp()
+  {
+    MineStat ms = new MineStat("minecraft.frag.land", 25565);
+    assertTrue(ms.isServerUp());
+  }
 }

--- a/Java/Test/me/dilley/MineStatTest.java
+++ b/Java/Test/me/dilley/MineStatTest.java
@@ -1,5 +1,7 @@
-/* JUnit tests for MineStat.java class */
-/* Contributed by Annukka Tormala (nukka) */
+/*
+ * JUnit tests for MineStat.java class
+ * Contributed by Annukka Tormala (nukka)
+ */
 
 package me.dilley;
 
@@ -11,7 +13,7 @@ public class MineStatTest
 	@Test
 	// Tests if address is correct
 	public void checkAddress()
-  {
+    {
 		MineStat ms = new MineStat("minecraft.frag.land", 25565);
 		ms.setAddress("minecraft.frag.land");
 		assertEquals("minecraft.frag.land", ms.getAddress());
@@ -20,7 +22,7 @@ public class MineStatTest
 	@Test
 	// Tests if port number is correct
 	public void checkPort()
-  {
+    {
 		MineStat ms = new MineStat("minecraft.frag.land", 25565);
 		ms.setPort(25565);
 		assertEquals(25565, ms.getPort());
@@ -29,7 +31,7 @@ public class MineStatTest
 	@Test
 	// Tests if version number is correct
 	public void checkVersion()
-  {
+    {
 		MineStat ms = new MineStat("minecraft.frag.land", 25565);
 		ms.setVersion("BungeeCord 1.8.x-1.12.x");
 		assertEquals("BungeeCord 1.8.x-1.12.x", ms.getVersion());
@@ -38,7 +40,7 @@ public class MineStatTest
 	@Test
 	// Tests if number of current players is correct
 	public void checkNumberOfCurrentPlayers()
-  {
+    {
 		MineStat ms = new MineStat("minecraft.frag.land", 25565);
 		ms.setCurrentPlayers(0);
 		assertEquals(0, ms.getCurrentPlayers());
@@ -47,7 +49,7 @@ public class MineStatTest
 	@Test
 	// Tests if number of maximum players is correct
 	public void checkNumberOfMaximumPlayers()
-  {
+    {
 		MineStat ms = new MineStat("minecraft.frag.land", 25565);
 		ms.setMaximumPlayers(32);
 		assertEquals(32, ms.getMaximumPlayers());
@@ -56,7 +58,7 @@ public class MineStatTest
 	@Test
 	// Tests if the message of the day is correct
 	public void checkMessageOfTheDay()
-  {
+    {
 		MineStat ms = new MineStat("minecraft.frag.land", 25565);
 		ms.setMotd("Frag Land");
 		assertEquals("Frag Land", ms.getMotd());
@@ -65,7 +67,7 @@ public class MineStatTest
 	@Test
 	// Tests if the server is up
 	public void checkThatServerIsUp()
-  {
+    {
 		MineStat ms = new MineStat("minecraft.frag.land", 25565);
 		assertTrue(ms.isServerUp());
 	}

--- a/Java/me/dilley/MineStat.java
+++ b/Java/me/dilley/MineStat.java
@@ -1,6 +1,6 @@
 /*
  * MineStat.java - A Minecraft server status checker
- * Copyright (C) 2014-2022 Lloyd Dilley
+ * Copyright (C) 2014-2024 Lloyd Dilley
  * http://www.dilley.me/
  *
  * This program is free software; you can redistribute it and/or modify
@@ -18,10 +18,6 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-/**
- * @author Lloyd Dilley
- */
-
 package me.dilley;
 
 import com.google.gson.*;
@@ -32,6 +28,9 @@ import java.util.Arrays;
 import java.util.Base64;
 import java.util.Date;
 
+/**
+ * @author Lloyd Dilley
+ */
 public class MineStat
 {
   public static final String VERSION = "3.0.6";         // MineStat version
@@ -59,7 +58,7 @@ public class MineStat
     private final int magicNumber;
     private final String shortDescription;
 
-    private ConnectionStatus(int magicNumber, String shortDescription) {
+    ConnectionStatus(int magicNumber, String shortDescription) {
         this.magicNumber = magicNumber;
         this.shortDescription = shortDescription;
     }
@@ -80,7 +79,7 @@ public class MineStat
 
     private final int request;
 
-    private Request(int request) { this.request = request; }
+    Request(int request) { this.request = request; }
 
     public int getRequest() { return request; }
   }

--- a/Java/me/dilley/MineStat.java
+++ b/Java/me/dilley/MineStat.java
@@ -58,9 +58,10 @@ public class MineStat
     private final int magicNumber;
     private final String shortDescription;
 
-    ConnectionStatus(int magicNumber, String shortDescription) {
-        this.magicNumber = magicNumber;
-        this.shortDescription = shortDescription;
+    private ConnectionStatus(int magicNumber, String shortDescription)
+    {
+      this.magicNumber = magicNumber;
+      this.shortDescription = shortDescription;
     }
 
     public int getMagicNumber() { return magicNumber; }
@@ -79,7 +80,7 @@ public class MineStat
 
     private final int request;
 
-    Request(int request) { this.request = request; }
+    private Request(int request) { this.request = request; }
 
     public int getRequest() { return request; }
   }

--- a/Java/pom.xml
+++ b/Java/pom.xml
@@ -43,6 +43,7 @@
       <artifactId>gson</artifactId>
       <version>2.11.0</version>
     </dependency>
+    
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>

--- a/Java/pom.xml
+++ b/Java/pom.xml
@@ -43,7 +43,6 @@
       <artifactId>gson</artifactId>
       <version>2.11.0</version>
     </dependency>
-    
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>

--- a/Java/pom.xml
+++ b/Java/pom.xml
@@ -1,11 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
-  <name>MineStat</name>
+
   <groupId>io.github.fragland</groupId>
   <artifactId>MineStat</artifactId>
   <version>3.0.6</version>
   <packaging>jar</packaging>
+
+  <name>MineStat</name>
   <description>MineStat is a Minecraft server status checker.</description>
   <url>https://github.com/fragland/minestat</url>
 
@@ -37,16 +39,15 @@
 
   <dependencies>
     <dependency>
+      <groupId>com.google.code.gson</groupId>
+      <artifactId>gson</artifactId>
+      <version>2.11.0</version>
+    </dependency>
+    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <version>4.13.2</version>
       <scope>test</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>com.google.code.gson</groupId>
-      <artifactId>gson</artifactId>
-      <version>2.11.0</version>
     </dependency>
   </dependencies>
 
@@ -64,6 +65,7 @@
     <plugins>
       <!-- Build .class files -->
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
         <version>3.13.0</version>
         <configuration>
@@ -151,7 +153,6 @@
               </execution>
             </executions>
           </plugin>
-
           <!-- Javadoc plugin -->
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
I changed the comment blocks for a better look and corrected the date to the current year. In addition, fixed the indentation in the test class.

In the `pom.xml` file, I moved the dependencies according to their usage, changed the protocol to `https` and moved the `name`, `description` and `url` tags to a separate section.

My opinion is to move the source code to the `src/main/java` directory and the test code to `src/test/java` in order not to reassign them to `sourceDirectory` and `testSourceDirectory`. But I don't often work with `pom.xml` so I can't guarantee the same build. In addition, I would like to change the indentation in the code from 2 to 4 as it usually is and change the position of the curly braces. The best option would be to add `.gitignore` and `.editorconfig` files to each project for each language.