### PR TITLE
Python: Use a higher protocol number to get the gradient motd.

### DIFF
--- a/Python/minestat/__init__.py
+++ b/Python/minestat/__init__.py
@@ -712,8 +712,8 @@ class MineStat:
 
     # Construct Handshake packet
     req_data = bytearray([0x00])
-    # Add protocol version. If pinging to determine version, use `-1`
-    req_data += bytearray([0xff, 0xff, 0xff, 0xff, 0x0f])
+    # Add protocol version. If pinging to determine version, use `25565`
+    req_data += bytearray([0xdd, 0xc7, 0x01])
     # Add server address length
     req_data += self._pack_varint(len(self.address))
     # Server address. Encoded with UTF8


### PR DESCRIPTION
## Proposed Changes
- Python: When performing a json query, send a higher protocol number to get the motd data (e.g. MiniMotd) that contains the correct gradient.
